### PR TITLE
unstable-feature/theme: Delegate rendering to classes

### DIFF
--- a/admin/security_roles.php
+++ b/admin/security_roles.php
@@ -177,7 +177,6 @@ $new_role = get_post('role')=='';
 check_cells(_("Show inactive:"), 'show_inactive', null, true);
 end_row();
 end_table();
-echo "<hr>";
 
 if (get_post('_show_inactive_update')) {
 	$Ajax->activate('role');

--- a/gl/includes/ui/gl_bank_ui.inc
+++ b/gl/includes/ui/gl_bank_ui.inc
@@ -248,7 +248,7 @@ function gl_edit_item_controls(&$order, $dim, $Index=null)
 			$_POST['code_id'] =
 				get_company_pref($payment ? 'default_cogs_act':'default_inv_sales_act');
 		}
-		echo gl_all_accounts_list('code_id', null, true, true);
+		ControlRenderer::get()->table_add_cells(gl_all_accounts_list('code_id', null, true, true));
 		if ($dim >= 1)
 			dimensions_list_cells(null, 'dimension_id', null, true, " ", false, 1);
 		if ($dim > 1)

--- a/includes/ui/ControlRenderer.inc
+++ b/includes/ui/ControlRenderer.inc
@@ -380,7 +380,6 @@ class ControlRenderer
 		echo "</tr>\n";
 	}
 
-	// TODO REVIEW: This function is no longer in stable CJP 2016-01
 	/**
 	 * @param array | string $cells
 	 */

--- a/includes/ui/ControlRenderer.inc
+++ b/includes/ui/ControlRenderer.inc
@@ -1,0 +1,709 @@
+<?php
+
+/**********************************************************************
+	Copyright (C) FrontAccounting, LLC.
+	Released under the terms of the GNU General Public License, GPL,
+	as published by the Free Software Foundation, either version 3
+	of the License, or (at your option) any later version.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+	See the License here <http://www.gnu.org/licenses/gpl-3.0.html>.
+***********************************************************************/
+
+include_once('InputRenderer.inc');
+
+// ---------------------------------------------------------------------------------
+class ControlRenderer
+{
+	/**
+	 *
+	 * @param ControlRenderer $controlRenderer
+	 * @return ControlRenderer
+	 */
+	public static function get($controlRenderer = null)
+	{
+		global $path_to_root;
+		static $instance = null;
+		if ($controlRenderer != null) {
+			$instance = $controlRenderer;
+		}
+		if ($instance == null) {
+			// Give the theme an opportunity to register a custom renderer
+			$themeName = user_theme();
+			if ($themeName) {
+				include_once($path_to_root . "/themes/".$themeName."/renderer.php");
+			}
+			// Otherwise create the default renderer
+			if ($instance == null) {
+				$instance = new ControlRenderer();
+			}
+		}
+		return $instance;
+	}
+
+	private $form_nested;
+	
+	function ControlRenderer() {
+		$this->form_nested = -1;
+	}
+	
+	function start_form($multi = false, $dummy = false, $action = "", $name = "")
+	{
+		// $dummy - leaved for compatibility with 2.0 API
+		
+		if (++$this->form_nested) return;
+		
+		if ($name != "")
+			$name = "name='$name'";
+		if ($action == "")
+			$action = $_SERVER['PHP_SELF'];
+
+		if ($multi)
+			echo "<form enctype='multipart/form-data' method='post' action='$action' $name>\n";
+		else
+			echo "<form method='post' action='$action' $name>\n";
+	}
+
+	private function output_hidden()
+	{
+		InputRenderer::get()->output_hidden();
+	}
+
+	// ---------------------------------------------------------------------------------
+	function end_form($breaks = 0)
+	{
+		global $Ajax;
+
+		if ($this->form_nested-- > 0) return;
+		
+		$_SESSION['csrf_token'] = hash('sha256', uniqid(mt_rand(), true));
+		if ($breaks)
+			br($breaks);
+		hidden('_focus');
+		hidden('_modified', get_post('_modified', 0));
+		hidden('_confirmed'); // helper for final form confirmation
+		hidden('_token', $_SESSION['csrf_token']);
+	
+		$this->output_hidden();
+		echo "</form>\n";
+		$Ajax->activate('_token');
+		$Ajax->activate('_confirmed');
+	}
+
+	function check_csrf_token()
+	{
+		if ($_SESSION['csrf_token'] != @$_POST['_token'])
+		{
+			display_error(_("Request from outside of this page is forbidden."));
+			error_log(_("CSRF attack detected from: ") . @$_SERVER['HTTP_HOST'] . ' (' . @$_SERVER['HTTP_REFERER'] . ')');
+			return false;
+		}
+		return true;
+	}
+
+	function start_table($class = false, $extra = "", $padding = '2', $spacing = '0')
+	{
+		echo "<center><table";
+		if ($class == TABLESTYLE_NOBORDER)
+			echo " class='tablestyle_noborder'";
+		elseif ($class == TABLESTYLE2)
+			echo " class='tablestyle2'";
+		elseif ($class == TABLESTYLE)
+			echo " class='tablestyle'";
+		if ($extra != "")
+			echo " $extra";
+		echo " cellpadding='$padding' cellspacing='$spacing'>\n";
+	}
+
+	function end_table($breaks = 0)
+	{
+		echo "</table></center>\n";
+		$this->output_hidden();
+		if ($breaks)
+			br($breaks);
+	}
+
+	function start_outer_table($class = false, $extra = "", $padding = '2', $spacing = '0', $br = false)
+	{
+		if ($br)
+			br();
+		start_table($class, $extra, $padding, $spacing);
+		echo "<tr valign=top><td>\n"; // outer table
+	}
+
+	function table_section($number = 1, $width = false)
+	{
+		if ($number > 1)
+		{
+			echo "</table>\n";
+			$this->output_hidden();
+			$width = ($width ? "width='$width'" : "");
+			echo "</td><td style='border-left:1px solid #cccccc;' $width>\n"; // outer table
+		}
+		echo "<table class='tablestyle_inner'>\n";
+	}
+
+	function end_outer_table($breaks = 0, $close_table = true)
+	{
+		if ($close_table)
+		{
+			echo "</table>\n";
+			$this->output_hidden();
+		}
+		echo "</td></tr>\n";
+		end_table($breaks);
+	}
+	//
+	// outer table spacer
+	//
+	function vertical_space($params = '')
+	{
+		echo "</td></tr><tr><td valign=center $params>";
+	}
+
+	function meta_forward($forward_to, $params = "", $timeout=0)
+	{
+		global $Ajax;
+		echo "<meta http-equiv='Refresh' content='".$timeout."; url=$forward_to?$params'>\n";
+		echo "<center><br>" . _("You should automatically be forwarded.");
+		echo " " . _("If this does not happen") . " " . "<a href='$forward_to?$params'>" . _("click here") . "</a> " . _("to continue") . ".<br><br></center>\n";
+		if ($params !='') $params = '?'.$params;
+		
+		$Ajax->redirect($forward_to . $params);
+		exit();
+	}
+
+	// -----------------------------------------------------------------------------------
+	// Find and replace hotkey marker.
+	// if $clean == true marker is removed and clean label is returned
+	// (for use in wiki help system), otherwise result is array of label
+	// with underlined hotkey letter and access property string.
+	//
+	function access_string($label, $clean = false)
+	{
+		$access = '';
+		$slices = array();
+
+		if (preg_match('/(.*)&([a-zA-Z0-9])(.*)/', $label, $slices))
+		{
+			$label = $clean ? $slices[1] . $slices[2] . $slices[3] : $slices[1] . '<u>' . $slices[2] . '</u>' . $slices[3];
+			$access = " accesskey='" . strtoupper($slices[2]) . "'";
+		}
+
+		$label = str_replace('&&', '&', $label);
+
+		return $clean ? $label : array($label, $access);
+	}
+
+	function hyperlink_back($center = true, $no_menu = true, $type_no = 0, $trans_no = 0, $final = false)
+	{
+		global $path_to_root;
+
+		if ($center)
+			echo "<center>";
+		$id = 0;
+		if ($no_menu && $trans_no != 0)
+		{
+			include_once ($path_to_root . "/admin/db/attachments_db.inc");
+			$id = has_attachment($type_no, $trans_no);
+			$attach = get_attachment_string($type_no, $trans_no);
+			echo $attach;
+		}
+		$width = ($id != 0 ? "30%" : "20%");
+		start_table(false, "width=$width");
+		start_row();
+		if ($no_menu)
+		{
+			echo "<td align=center><a href='javascript:window.print();'>" . _("Print") . "</a></td>\n";
+		}
+		echo "<td align=center><a href='javascript:goBack(" . ($final ? '-2' : '') . ");'>" . ($no_menu ? _("Close") : _("Back")) . "</a></td>\n";
+		end_row();
+		end_table();
+		if ($center)
+			echo "</center>";
+		echo "<br>";
+	}
+
+	function hyperlink_no_params($target, $label, $center = true)
+	{
+		$id = default_focus();
+		$pars = access_string($label);
+		if ($target == '')
+			$target = $_SERVER['PHP_SELF'];
+		if ($center)
+			echo "<br><center>";
+		echo "<a href='$target' id='$id' $pars[1]>$pars[0]</a>\n";
+		if ($center)
+			echo "</center>";
+	}
+
+	function hyperlink_no_params_td($target, $label)
+	{
+		echo "<td>";
+		hyperlink_no_params($target, $label);
+		echo "</td>\n";
+	}
+
+	function viewer_link($label, $url = '', $class = '', $id = '', $icon = null)
+	{
+		global $path_to_root;
+
+		if ($class != '')
+			$class = " class='$class'";
+
+		if ($id != '')
+			$class = " id='$id'";
+
+		if ($url != "")
+		{
+			$pars = access_string($label);
+			if (user_graphic_links() && $icon)
+				$pars[0] = set_icon($icon, $pars[0]);
+			$preview_str = "<a target='_blank' $class $id href='$path_to_root/$url' onclick=\"javascript:openWindow(this.href,this.target); return false;\"$pars[1]>$pars[0]</a>";
+		}
+		else
+			$preview_str = $label;
+		return $preview_str;
+	}
+
+	function menu_link($url, $label, $id = null)
+	{
+		global $path_to_root;
+		
+		$id = default_focus($id);
+		$pars = access_string($label);
+		
+		// REVIEW: The addition of $path_to_root to $url seems unnecessary or wrong CJP 2016-01
+		if ($url[0] != '/')
+			$url = '/'.$url;
+		$url = $path_to_root.$url;
+		return "<a href='$url' class='menu_option' id='$id' $pars[1]>$pars[0]</a>";
+	}
+
+	function submenu_option($title, $url, $id = null)
+	{
+		display_note(menu_link($url, $title, $id), 0, 1);
+	}
+
+	function submenu_view($title, $type, $number, $id = null)
+	{
+		display_note(get_trans_view_str($type, $number, $title, false, 'viewlink', $id), 0, 1);
+	}
+
+	function submenu_print($title, $type, $number, $id = null, $email = 0, $extra = 0)
+	{
+		display_note(print_document_link($number, $title, true, $type, false, 'printlink', $id, $email, $extra), 0, 1);
+	}
+	// -----------------------------------------------------------------------------------
+	function hyperlink_params($target, $label, $params, $center = true)
+	{
+		$id = default_focus();
+
+		$pars = access_string($label);
+		if ($target == '')
+			$target = $_SERVER['PHP_SELF'];
+		if ($center)
+			echo "<br><center>";
+		echo "<a id='$id' href='$target?$params'$pars[1]>$pars[0]</a>\n";
+		if ($center)
+			echo "</center>";
+	}
+
+	function hyperlink_params_td($target, $label, $params)
+	{
+		echo "<td>";
+		hyperlink_params($target, $label, $params, false);
+		echo "</td>\n";
+	}
+
+	// -----------------------------------------------------------------------------------
+	function hyperlink_params_separate($target, $label, $params, $center = false)
+	{
+		$id = default_focus();
+
+		$pars = access_string($label);
+		if ($center)
+			echo "<br><center>";
+		echo "<a target='_blank' id='$id' href='$target?$params' $pars[1]>$pars[0]</a>\n";
+		if ($center)
+			echo "</center>";
+	}
+
+	function hyperlink_params_separate_td($target, $label, $params)
+	{
+		echo "<td>";
+		hyperlink_params_separate($target, $label, $params);
+		echo "</td>\n";
+	}
+
+	// --------------------------------------------------------------------------------------------------
+	function alt_table_row_color(&$k, $extra_class = null)
+	{
+		$classes = $extra_class ? array($extra_class) : array();
+		if ($k == 1)
+		{
+			array_push($classes, 'oddrow');
+			$k = 0;
+		}
+		else
+		{
+			array_push($classes, 'evenrow');
+			$k ++;
+		}
+		echo "<tr class='" . implode(' ', $classes) . "'>\n";
+	}
+
+	function table_section_title($msg, $colspan = 2)
+	{
+		echo "<tr><td colspan=$colspan class='tableheader'>$msg</td></tr>\n";
+	}
+
+	function table_header($labels, $params = '')
+	{
+		start_row();
+		foreach ($labels as $label)
+			labelheader_cell($label, $params);
+		end_row();
+	}
+	// -----------------------------------------------------------------------------------
+	function start_row($param = "")
+	{
+		if ($param != "")
+			echo "<tr $param>\n";
+		else
+			echo "<tr>\n";
+	}
+
+	function end_row()
+	{
+		echo "</tr>\n";
+	}
+
+	// TODO REVIEW: This function is no longer in stable CJP 2016-01
+	/**
+	 * @param array | string $cells
+	 */
+	function table_add_cells($cells)
+	{
+		if (is_array($cells)) {
+			foreach ($cells as $cell) {
+				echo $cell;
+			}
+		} else {
+			echo $cells;
+		}
+	}
+
+	function br($num = 1)
+	{
+		for ($i = 0; $i < $num; $i ++)
+			echo "<br>";
+	}
+
+	var $ajax_divs = array();
+
+	function div_start($id = '', $trigger = null, $non_ajax = false)
+	{
+		if ($non_ajax) { // div for non-ajax elements
+			array_push($this->ajax_divs, array($id, null));
+			echo "<div style='display:none' class='js_only' " . ($id != '' ? "id='$id'" : '') . ">";
+		} else { // ajax ready div
+			array_push($this->ajax_divs, array($id, $trigger === null ? $id : $trigger));
+			echo "<div " . ($id != '' ? "id='$id'" : '') . ">";
+			ob_start();
+		}
+	}
+
+	function div_end()
+	{
+		global $Ajax;
+
+		$this->output_hidden();
+		if (count($this->ajax_divs))
+		{
+			$div = array_pop($this->ajax_divs);
+			if ($div[1] !== null)
+				$Ajax->addUpdate($div[1], $div[0], ob_get_flush());
+			echo "</div>";
+		}
+	}
+
+	// -----------------------------------------------------------------------------
+	// Tabbed area:
+	// $name - prefix for widget internal elements:
+	// Nth tab submit name: {$name}_N
+	// div id: _{$name}_div
+	// sel (hidden) name: _{$name}_sel
+	// $tabs - array of tabs; string: tab title or array(tab_title, enabled_status)
+	function tabbed_content_start($name, $tabs, $dft = '')
+	{
+		global $Ajax;
+
+		$selname = '_' . $name . '_sel';
+		$div = '_' . $name . '_div';
+
+		$sel = find_submit($name . '_', false);
+		if ($sel == null)
+			$sel = get_post($selname, (string) ($dft === '' ? key($tabs) : $dft));
+
+		if ($sel !== @$_POST[$selname])
+			$Ajax->activate($name);
+
+		$_POST[$selname] = $sel;
+
+		div_start($name);
+		$str = "<ul class='ajaxtabs' rel='$div'>\n";
+		foreach ($tabs as $tab_no => $tab) {
+
+			$acc = access_string(is_array($tab) ? $tab[0] : $tab);
+			$disabled = (is_array($tab) && ! $tab[1]) ? 'disabled ' : '';
+			$str .= ("<li>" . "<button type='submit' name='{$name}_" . $tab_no . "' class='" . ((string) $tab_no === $sel ? 'current' : 'ajaxbutton') . "' $acc[1] $disabled>" . "<span>$acc[0]</span>" . "</button>\n" . "</li>\n");
+		}
+
+		$str .= "</ul>\n";
+		$str .= "<div class='spaceBox'></div>\n";
+		$str .= "<input type='hidden' name='$selname' value='$sel'>\n";
+		$str .= "<div class='contentBox' id='$div'>\n";
+		echo $str;
+	}
+
+	function tabbed_content_end()
+	{
+		$this->output_hidden();
+		echo "</div>"; // content box (don't change to div_end() unless div_start() is used above)
+		div_end(); // tabs widget
+	}
+
+	function tab_changed($name)
+	{
+		$to = find_submit("{$name}_", false);
+		if (! $to)
+			return null;
+
+		return array(
+			'from' => $from = get_post("_{$name}_sel"),
+			'to' => $to
+		);
+	}
+
+	/*
+	 Check whether tab has been just switched on
+	 */
+	function tab_opened($name, $tab)
+	{
+		return (get_post('_'.$name.'_sel') != $tab) && (find_submit($name.'_', false) == $tab);
+	}
+	/*
+	 Check whether tab has been just switched off
+	 */
+	function tab_closed($name, $tab)
+	{
+		return (get_post('_'.$name.'_sel') == $tab) && (find_submit($name.'_', false) != $tab);
+	}
+	/*
+	 Check whether tab is visible on current page
+	 */
+	function tab_visible($name, $tab)
+	{
+		$new = find_submit($name.'_', false);
+		return (get_post('_'.$name.'_sel') == $tab && !$new) || $new==$tab;
+	}
+	
+	function pager_link($link_text, $url, $icon = false)
+	{
+		global $path_to_root;
+
+		if (user_graphic_links() && $icon)
+			$link_text = set_icon($icon, $link_text);
+
+		$href = $path_to_root . $url;
+		return "<a href='$href'>" . $link_text . "</a>";
+	}
+
+	function pager_button($name, $value, $enabled = true, $icon = false)
+	{
+		global $path_to_root;
+		return "<button " . ($enabled ? '' : 'disabled') . " class=\"navibutton\" type=\"submit\"" . " name=\"$name\"  id=\"$name\" value=\"$value\">" . ($icon ? "<img src='$path_to_root/themes/" . user_theme() . "/images/" . $icon . "'>" : '') . "<span>$value</span></button>\n";
+	}
+
+	function pager_button_cell($name, $value, $enabled = true, $align = 'left')
+	{
+		label_cell(navi_button($name, $value, $enabled), "align='$align'");
+	}
+
+	// -----------------------------------------------------------------------------
+	//
+	// Sql paged table view. Call this function inside form.
+	//
+	function pager(&$pager)
+	{
+		global $path_to_root;
+
+		$pager->select_records();
+
+		div_start("_{$pager->name}_span");
+		$headers = array();
+
+		foreach ($pager->columns as $num_col => $col) {
+			// record status control column is displayed only when control checkbox is on
+			if (isset($col['head']) && ($col['type'] != 'inactive' || get_post('show_inactive'))) {
+				if (! isset($col['ord']))
+					$headers[] = $col['head'];
+				else {
+					$icon = (($col['ord'] == 'desc') ? 'sort_desc.gif' : ($col['ord'] == 'asc' ? 'sort_asc.gif' : 'sort_none.gif'));
+					$headers[] = navi_button($pager->name . '_sort_' . $num_col, $col['head'], true, $icon);
+				}
+			}
+		}
+		/* show a table of records returned by the sql */
+		start_table(TABLESTYLE, "width=$pager->width");
+		table_header($headers);
+
+		if ($pager->header_fun) { // if set header handler
+			start_row("class='{$pager->header_class}'");
+			$fun = $pager->header_fun;
+			if (method_exists($pager, $fun)) {
+				$h = $pager->$fun($pager);
+			} elseif (function_exists($fun)) {
+				$h = $fun($pager);
+			}
+
+			foreach ($h as $c) { // draw header columns
+				$pars = isset($c[1]) ? $c[1] : '';
+				label_cell($c[0], $pars);
+			}
+			end_row();
+		}
+
+		$cc = 0; // row colour counter
+		foreach ($pager->data as $line_no => $row) {
+
+			$marker = $pager->marker;
+			if ($marker && $marker($row))
+				start_row("class='$pager->marker_class'");
+			else
+				alt_table_row_color($cc);
+			foreach ($pager->columns as $k => $col) {
+				$coltype = $col['type'];
+				$cell = isset($col['name']) ? $row[$col['name']] : '';
+
+				if (isset($col['fun'])) { // use data input function if defined
+					$fun = $col['fun'];
+					if (method_exists($pager, $fun)) {
+						$cell = $pager->$fun($row, $cell);
+					} elseif (function_exists($fun)) {
+						$cell = $fun($row, $cell);
+					} else
+						$cell = '';
+				}
+				switch ($coltype) { // format column
+					case 'time':
+						label_cell($cell, "width=40");
+						break;
+					case 'date':
+						label_cell(sql2date($cell), "align='center' nowrap");
+						break;
+					case 'dstamp': // time stamp displayed as date
+						label_cell(sql2date(substr($cell, 0, 10)), "align='center' nowrap");
+						break;
+					case 'tstamp': // time stamp - FIX user format
+						label_cell(sql2date(substr($cell, 0, 10)) . ' ' . substr($cell, 10), "align='center'");
+						break;
+					case 'percent':
+						percent_cell($cell);
+						break;
+					case 'amount':
+						if ($cell == '')
+							label_cell('');
+						else
+							amount_cell($cell, false);
+						break;
+					case 'qty':
+						if ($cell == '')
+							label_cell('');
+						else
+							qty_cell($cell, false, isset($col['dec']) ? $col['dec'] : null);
+						break;
+					case 'email':
+						email_cell($cell, isset($col['align']) ? "align='" . $col['align'] . "'" : null);
+						break;
+					case 'rate':
+						label_cell(number_format2($cell, user_exrate_dec()), "align=center");
+						break;
+					case 'inactive':
+						if (get_post('show_inactive'))
+							$pager->inactive_control_cell($row);
+						break;
+					default:
+						if (isset($col['align']))
+							label_cell($cell, "align='" . $col['align'] . "'");
+						else
+							label_cell($cell);
+					case 'skip': // column not displayed
+				}
+			}
+			end_row();
+		}
+		// end of while loop
+
+		if ($pager->footer_fun) { // if set footer handler
+			start_row("class='{$pager->footer_class}'");
+			$fun = $pager->footer_fun;
+			if (method_exists($pager, $fun)) {
+				$h = $pager->$fun($pager);
+			} elseif (function_exists($fun)) {
+				$h = $fun($pager);
+			}
+
+			foreach ($h as $c) { // draw footer columns
+				$pars = isset($c[1]) ? $c[1] : '';
+				label_cell($c[0], $pars);
+			}
+			end_row();
+		}
+
+		start_row("class='navibar'");
+		$colspan = count($pager->columns);
+		$inact = @$pager->inactive_ctrl == true ? ' ' . checkbox(null, 'show_inactive', null, true) . _("Show also Inactive") : '';
+		if ($pager->rec_count) {
+			echo "<td colspan=$colspan class='navibar' style='border:none;padding:3px;'>";
+			echo "<div style='float:right;'>";
+			$but_pref = $pager->name . '_page_';
+			start_table();
+			start_row();
+			if (@$pager->inactive_ctrl)
+				submit('Update', _('Update'), true, '', null); // inactive update
+			echo navi_button_cell($but_pref . 'first', _('First'), $pager->first_page, 'right');
+			echo navi_button_cell($but_pref . 'prev', _('Prev'), $pager->prev_page, 'right');
+			echo navi_button_cell($but_pref . 'next', _('Next'), $pager->next_page, 'right');
+			echo navi_button_cell($but_pref . 'last', _('Last'), $pager->last_page, 'right');
+			end_row();
+			end_table();
+			echo "</div>";
+			$from = ($pager->curr_page - 1) * $pager->page_len + 1;
+			$to = $from + $pager->page_len - 1;
+			if ($to > $pager->rec_count)
+				$to = $pager->rec_count;
+			$all = $pager->rec_count;
+			echo sprintf(_('Records %d-%d of %d'), $from, $to, $all);
+			echo $inact;
+			echo "</td>";
+		} else {
+			label_cell(_('No records') . $inact, "colspan=$colspan class='navibar'");
+		}
+
+		end_row();
+
+		end_table();
+
+		if (isset($pager->marker_txt))
+			display_note($pager->marker_txt, 0, 1, "class='$pager->notice_class'");
+
+		div_end();
+		return true;
+	}
+
+}
+
+?>

--- a/includes/ui/InputRenderer.inc
+++ b/includes/ui/InputRenderer.inc
@@ -1,0 +1,1001 @@
+<?php
+
+/**********************************************************************
+    Copyright (C) FrontAccounting, LLC.
+	Released under the terms of the GNU General Public License, GPL,
+	as published by the Free Software Foundation, either version 3
+	of the License, or (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the License here <http://www.gnu.org/licenses/gpl-3.0.html>.
+***********************************************************************/
+// ---------------------------------------------------------------------------------
+class InputRenderer
+{
+
+	/**
+	 *
+	 * @param InputRenderer $inputRenderer
+	 * @return InputRenderer
+	 */
+	public static function get($inputRenderer = null)
+	{
+		global $path_to_root;
+		static $instance = null;
+		if ($inputRenderer != null) {
+			$instance = $inputRenderer;
+		}
+		if ($instance == null) {
+			// Give the theme an opportunity to register a custom renderer
+			$themeName = user_theme();
+			if ($themeName) {
+				include_once ($path_to_root . "/themes/" . $themeName . "/renderer.php");
+			}
+			// Otherwise create the default renderer
+			if ($instance == null) {
+				$instance = new InputRenderer();
+			}
+		}
+		return $instance;
+	}
+
+	// ------------------------------------------------------------------------------
+	// Seek for _POST variable with $prefix.
+	// If var is found returns variable name with prefix stripped,
+	// and null or -1 otherwise.
+	//
+	function find_submit($prefix, $numeric = true)
+	{
+		foreach ($_POST as $postkey => $postval)
+		{
+			if (strpos($postkey, $prefix) === 0)
+			{
+				$id = substr($postkey, strlen($prefix));
+				return $numeric ? (int) $id : $id;
+			}
+		}
+		return $numeric ? - 1 : null;
+	}
+
+	/*
+	 Helper function.
+	 Returns true if input $name with $submit_on_change option set is subject to update.
+	 */
+	function input_changed($name)
+	{
+		return isset($_POST['_'.$name.'_changed']);
+	}
+	
+	// ------------------------------------------------------------------------------
+	//
+	// Helper function for simple db table editor pages
+	//
+	function simple_page_mode($numeric_id = true)
+	{
+		global $Ajax, $Mode, $selected_id;
+
+		$default = $numeric_id ? - 1 : '';
+		$selected_id = get_post('selected_id', $default);
+		foreach (array(
+			'ADD_ITEM',
+			'UPDATE_ITEM',
+			'RESET',
+			'CLONE'
+		) as $m) {
+			if (isset($_POST[$m])) {
+				$Ajax->activate('_page_body');
+				if ($m == 'RESET' || $m == 'CLONE')
+					$selected_id = $default;
+				unset($_POST['_focus']);
+				$Mode = $m;
+				return;
+			}
+		}
+		foreach (array(
+			'Edit',
+			'Delete'
+		) as $m) {
+			foreach ($_POST as $p => $pvar) {
+				if (strpos($p, $m) === 0) {
+					// $selected_id = strtr(substr($p, strlen($m)), array('%2E'=>'.'));
+					unset($_POST['_focus']); // focus on first form entry
+					$selected_id = quoted_printable_decode(substr($p, strlen($m)));
+					$Ajax->activate('_page_body');
+					$Mode = $m;
+					return;
+				}
+			}
+		}
+		$Mode = '';
+	}
+
+	// ------------------------------------------------------------------------------
+	//
+	// Read numeric value from user formatted input
+	//
+	function input_num($postname = null, $dflt = 0)
+	{
+		if (! isset($_POST[$postname]) || $_POST[$postname] == "")
+			return $dflt;
+
+		return user_numeric($_POST[$postname]);
+	}
+
+	// ---------------------------------------------------------------------------------
+	//
+	//  Thanks to hidden fields buffering hidden() helper can be used in arbitrary places and 
+	//  proper html structure is still preserved. Buffered hidden fields are output on the nearest 
+	//  table or form closing tag (see output_hidden()).
+	//
+	var $hidden_fields = array();
+
+	function hidden($name, $value = null, $echo = true)
+	{
+		global $Ajax;
+
+		if ($value === null)
+			$value = get_post($name);
+
+		$ret = "<input type=\"hidden\" name=\"$name\" value=\"$value\">";
+		$Ajax->addUpdate($name, $name, $value);
+		if ($echo)
+			$this->hidden_fields[] = $ret;
+		else
+			return $ret;
+	}
+	
+	/*
+	Flush hidden fields buffer.
+	*/
+	function output_hidden()
+	{
+		if (is_array($this->hidden_fields))
+			echo implode('', $this->hidden_fields);
+		$this->hidden_fields = array();
+	}
+
+	/*
+	Universal submit form button.
+	$atype - type of submit:
+	 Normal submit:
+		false - normal button; optional icon
+		null  - button visible only in fallback mode; optional icon
+	 Ajax submit:
+		true	  - standard button; optional icon
+
+		'default' - default form submit on Ctrl-Enter press; dflt ICON_OK icon
+		'selector' - ditto with closing current popup editor window
+		'cancel'  - cancel form entry on Escape press; dflt ICON_CANCEL
+		'process' - displays progress bar during call; optional icon
+		'nonajax' - ditto, non-ajax submit
+
+	$atype can contain also multiply type selectors separated by space, 
+	however make sense only combination of 'process' and one of defualt/selector/cancel
+	*/
+	function submit($name, $value, $echo = true, $title = false, $atype = false, $icon = false)
+	{
+		global $path_to_root;
+
+		$aspect = '';
+		if ($atype === null) {
+			$aspect = fallback_mode() ? " aspect='fallback'" : " style='display:none;'";
+		} elseif (! is_bool($atype)) { // necessary: switch uses '=='
+
+			$aspect = "aspect='$atype' ";
+			$types = explode(' ', $atype);
+
+			foreach ($types as $type) {
+				switch ($type) {
+					case 'selector':
+						$aspect = " aspect='selector' rel = '$value'";
+						$value = _("Select");
+						if ($icon === false)
+							$icon = ICON_SUBMIT;
+						break;
+
+					case 'default':
+						if ($icon === false)
+							$icon = ICON_SUBMIT;
+						break;
+
+					case 'cancel':
+						if ($icon === false)
+							$icon = ICON_ESCAPE;
+						break;
+
+					case 'nonajax':
+						$atype = false;
+				}
+			}
+		}
+		$submit_str = "<button class=\"" . ($atype ? 'ajaxsubmit' : 'inputsubmit') . "\" type=\"submit\"" . $aspect . " name=\"$name\"  id=\"$name\" value=\"$value\"" . ($title ? " title='$title'" : '') . ">" . ($icon ? "<img src='$path_to_root/themes/" . user_theme() . "/images/$icon' height='12'>" : '') . "<span>$value</span>" . "</button>\n";
+		if ($echo)
+			echo $submit_str;
+		else
+			return $submit_str;
+	}
+
+	function submit_center($name, $value, $echo = true, $title = false, $async = false, $icon = false)
+	{
+		if ($echo)
+			echo "<center>";
+		submit($name, $value, $echo, $title, $async, $icon);
+		if ($echo)
+			echo "</center>";
+	}
+
+	function submit_center_first($name, $value, $title = false, $async = false, $icon = false)
+	{
+		echo "<center>";
+		submit($name, $value, true, $title, $async, $icon);
+		echo "&nbsp;";
+	}
+
+	function submit_center_last($name, $value, $title = false, $async = false, $icon = false)
+	{
+		echo "&nbsp;";
+		submit($name, $value, true, $title, $async, $icon);
+		echo "</center>";
+	}
+	/*
+	For following controls:
+		'both' - use both Ctrl-Enter and Escape hotkeys 
+		'upgrade' - use Ctrl-Enter with progress ajax indicator and Escape hotkeys. Nonajax request for OK option is performed.
+		'cancel' - apply to 'RESET' button
+	 */
+	function submit_add_or_update($add = true, $title = false, $async = false, $clone = false)
+	{
+		$cancel = $async;
+
+		if ($async === 'both') {
+			$async = 'default';
+			$cancel = 'cancel';
+		} elseif ($async === 'upgrade') {
+			$async = 'default nonajax process';
+			$cancel = 'cancel';
+		} else if ($async === 'default')
+			$cancel = true;
+		else if ($async === 'cancel')
+			$async = true;
+
+		if ($add)
+			submit('ADD_ITEM', _("Add new"), true, $title, $async);
+		else {
+			submit('UPDATE_ITEM', _("Update"), true, _('Submit changes'), $async);
+			if ($clone)
+				submit('CLONE', _("Clone"), true, _('Edit new record with current data'), $async);
+			submit('RESET', _("Cancel"), true, _('Cancel edition'), $cancel);
+		}
+	}
+
+	function submit_add_or_update_center($add = true, $title = false, $async = false, $clone = false)
+	{
+		echo "<center>";
+		submit_add_or_update($add, $title, $async, $clone);
+		echo "</center>";
+	}
+
+	function submit_add_or_update_row($add = true, $right = true, $extra = "", $title = false, $async = false, $clone = false)
+	{
+		echo "<tr>";
+		if ($right)
+			echo "<td>&nbsp;</td>\n";
+		echo "<td $extra>";
+		submit_add_or_update($add, $title, $async, $clone);
+		echo "</td></tr>\n";
+	}
+
+	function submit_cells($name, $value, $extra = "", $title = false, $async = false)
+	{
+		echo "<td $extra>";
+		submit($name, $value, true, $title, $async);
+		echo "</td>\n";
+	}
+
+	function submit_row($name, $value, $right = true, $extra = "", $title = false, $async = false)
+	{
+		echo "<tr>";
+		if ($right)
+			echo "<td>&nbsp;</td>\n";
+		submit_cells($name, $value, $extra, $title, $async);
+		echo "</tr>\n";
+	}
+
+	function submit_return($name, $value, $title = false)
+	{
+		if (@$_REQUEST['popup']) {
+			submit($name, $value, true, $title, 'selector');
+		}
+	}
+
+	function submit_js_confirm($name, $msg, $set = true)
+	{
+		global $Ajax;
+		$js = "_validate.$name=" . ($set ? "function(){ return confirm('" . strtr($msg, array(
+			"\n" => '\\n'
+		)) . "');};" : 'null;');
+		if (in_ajax()) {
+			$Ajax->addScript(true, $js);
+		} else
+			add_js_source($js);
+	}
+	// -----------------------------------------------------------------------------------
+	function set_icon($icon, $title = false)
+	{
+		global $path_to_root;
+		if (basename($icon) === $icon) // standard icons does not contain path separator
+			$icon = "$path_to_root/themes/" . user_theme() . "/images/$icon";
+		return "<img src='$icon' style='vertical-align:middle;width:12px;height:12px;border:0;'".($title ? " title='$title'" : "")." >\n";
+	}
+
+	function button($name, $value, $title = false, $icon = false, $aspect = '')
+	{
+		// php silently changes dots,spaces,'[' and characters 128-159
+		// to underscore in POST names, to maintain compatibility with register_globals
+		$rel = '';
+		if ($aspect == 'selector') {
+			$rel = " rel='$value'";
+			$value = _("Select");
+		}
+		if (user_graphic_links() && $icon) {
+			if ($value == _("Delete")) // Helper during implementation
+				$icon = ICON_DELETE;
+				return "<button type='submit' class='editbutton' name='"
+					.htmlentities(strtr($name, array('.'=>'=2E', '='=>'=3D',// ' '=>'=20','['=>'=5B'
+					)))
+					."' value='1'" . ($title ? " title='$title'":" title='$value'")
+					. ($aspect ? " aspect='$aspect'" : '')
+					. $rel
+					." >".set_icon($icon)."</button>\n";
+			}
+			else
+				return "<input type='submit' class='editbutton' name='"
+					.htmlentities(strtr($name, array('.'=>'=2E', '='=>'=3D',// ' '=>'=20','['=>'=5B'
+					)))
+					."' value='$value'"
+					.($title ? " title='$title'":'')
+					. ($aspect ? " aspect='$aspect'" : '')
+					. $rel
+					." >\n";
+	}
+
+	function button_cell($name, $value, $title = false, $icon = false, $aspect = '')
+	{
+		echo "<td align='center'>";
+		echo button($name, $value, $title, $icon, $aspect);
+		echo "</td>";
+	}
+
+	function delete_button_cell($name, $value, $title = false)
+	{
+		button_cell($name, $value, $title, ICON_DELETE);
+	}
+
+	function edit_button_cell($name, $value, $title = false)
+	{
+		button_cell($name, $value, $title, ICON_EDIT);
+	}
+
+	function select_button_cell($name, $value, $title = false)
+	{
+		button_cell($name, $value, $title, ICON_ADD, 'selector');
+	}
+	// -----------------------------------------------------------------------------------
+	function check_value($name)
+	{
+		if (!isset($_POST[$name]) || $_POST[$name]=='')
+			return 0;
+		return 1;
+	}
+
+	function checkbox($label, $name, $value = null, $submit_on_change = false, $title = false)
+	{
+		global $Ajax;
+
+		$str = '';
+
+		if ($label)
+			$str .= $label . "  ";
+		if ($submit_on_change !== false) {
+			if ($submit_on_change === true)
+				$submit_on_change = "JsHttpRequest.request(\"_{$name}_update\", this.form);";
+		}
+		if ($value === null)
+			$value = get_post($name, 0);
+
+		$str .= "<input" . ($value == 1 ? ' checked' : '') . " type='checkbox' name='$name' value='1'" . ($submit_on_change ? " onclick='$submit_on_change'" : '') . ($title ? " title='$title'" : '') . " >\n";
+
+		$Ajax->addUpdate($name, $name, $value);
+		return $str;
+	}
+
+	function check($label, $name, $value = null, $submit_on_change = false, $title = false)
+	{
+		echo checkbox($label, $name, $value, $submit_on_change, $title);
+	}
+
+	function check_cells($label, $name, $value = null, $submit_on_change = false, $title = false, $params = '')
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td $params>";
+		echo check(null, $name, $value, $submit_on_change, $title);
+		echo "</td>";
+	}
+
+	function check_row($label, $name, $value = null, $submit_on_change = false, $title = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		echo check_cells(NULL, $name, $value, $submit_on_change, $title);
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------
+	function radio($label, $name, $value, $selected = null, $submit_on_change = false)
+	{
+		if (! isset($selected))
+			$selected = get_post($name) === (string)$value;
+
+		if ($submit_on_change === true)
+			$submit_on_change = "JsHttpRequest.request(\"_{$name}_update\", this.form);";
+
+		return "<input type='radio' name=$name value='$value' " . ($selected ? "checked" : '') . ($submit_on_change ? " onclick='$submit_on_change'" : '') . ">" . ($label ? $label : '');
+	}
+
+	// -----------------------------------------------------------------------------------
+	function labelheader_cell($label, $params = "")
+	{
+		echo "<td class='tableheader' $params>$label</td>\n";
+	}
+
+	function label_cell($label, $params = "", $id = null)
+	{
+		global $Ajax;
+
+		if (isset($id)) {
+			$params .= " id='$id'";
+			$Ajax->addUpdate($id, $id, $label);
+		}
+		echo "<td $params>$label</td>\n";
+
+		return $label;
+	}
+
+	function email_cell($label, $params = "", $id = null)
+	{
+		label_cell("<a href='mailto:$label'>$label</a>", $params, $id);
+	}
+
+	function amount_decimal_cell($label, $params = "", $id = null)
+	{
+		$dec = 0;
+		label_cell(price_decimal_format($label, $dec), "nowrap align=right " . $params, $id);
+	}
+
+	function amount_cell($label, $bold = false, $params = "", $id = null)
+	{
+		if ($bold)
+			label_cell("<b>" . price_format($label) . "</b>", "nowrap align=right " . $params, $id);
+		else
+			label_cell(price_format($label), "nowrap align=right " . $params, $id);
+	}
+
+	// JAM Allow entered unit prices to be fractional
+	function unit_amount_cell($label, $bold = false, $params = "", $id = null)
+	{
+		if ($bold)
+			label_cell("<b>" . unit_price_format($label) . "</b>", "nowrap align=right " . $params, $id);
+		else
+			label_cell(unit_price_format($label), "nowrap align=right " . $params, $id);
+	}
+
+	function percent_cell($label, $bold = false, $id = null)
+	{
+		if ($bold)
+			label_cell("<b>" . percent_format($label) . "</b>", "nowrap align=right", $id);
+		else
+			label_cell(percent_format($label), "nowrap align=right", $id);
+	}
+	// 2008-06-15. Changed
+	function qty_cell($label, $bold = false, $dec = null, $id = null)
+	{
+		if (! isset($dec))
+			$dec = get_qty_dec();
+		if ($bold)
+			label_cell("<b>" . number_format2($label, $dec) . "</b>", "nowrap align=right", $id);
+		else
+			label_cell(number_format2($label, $dec), "nowrap align=right", $id);
+	}
+
+	function label_cells($label, $value, $params = "", $params2 = "", $id = '')
+	{
+		if ($label != null)
+			echo "<td $params>$label</td>\n";
+		label_cell($value, $params2, $id);
+	}
+
+	function label_row($label, $value, $params = "", $params2 = "", $leftfill = 0, $id = '')
+	{
+		echo "<tr>";
+		if ($params == "") {
+			echo "<td class='label'>$label</td>";
+			$label = null;
+		}
+		label_cells($label, $value, $params, $params2, $id);
+		if ($leftfill != 0)
+			echo "<td colspan=$leftfill></td>";
+		echo "</tr>\n";
+	}
+
+	function text_input($name, $value = null, $size = '', $max = '', $title = '', $params = '')
+	{
+		if ($value === null)
+			$value = get_post($name);
+	
+		return "<input $params type=\"text\" name=\"$name\" size=\"$size\" maxlength=\"$max\" value=\"$value\""
+			.($title ? " title='$title'" : '')
+			.">";
+	}
+	
+	// -----------------------------------------------------------------------------------
+	function text_cells($label, $name, $value = null, $size = "", $max = "", $title = false, $labparams = "", $post_label = "", $inparams = "")
+	{
+		global $Ajax;
+
+		default_focus($name);
+		if ($label != null)
+			label_cell($label, $labparams);
+		echo "<td>";
+
+		echo $this->text_input($name, $value, $size, $max, $title, $inparams);
+
+		if ($post_label != "")
+			echo " " . $post_label;
+
+		echo "</td>\n";
+		$Ajax->addUpdate($name, $name, $value);
+	}
+
+	function text_cells_ex($label, $name, $size, $max = null, $init = null, $title = null, $labparams = null, $post_label = null, $submit_on_change = false)
+	{
+		global $Ajax;
+
+		default_focus($name);
+		if (! isset($_POST[$name]) || $_POST[$name] == "") {
+			if ($init)
+				$_POST[$name] = $init;
+			else
+				$_POST[$name] = "";
+		}
+		if ($label != null)
+			label_cell($label, $labparams);
+
+		if (! isset($max))
+			$max = $size;
+
+		echo "<td>";
+		$class = $submit_on_change ? 'class="searchbox"' : '';
+		echo "<input $class type=\"text\" name=\"$name\" size=\"$size\" maxlength=\"$max\" value=\"" . $_POST[$name] . "\"" . ($title ? " title='$title'" : '') . " >";
+
+		if ($post_label)
+			echo " " . $post_label;
+
+		echo "</td>\n";
+		$Ajax->addUpdate($name, $name, $_POST[$name]);
+	}
+
+	function text_row($label, $name, $value, $size, $max, $title = null, $params = "", $post_label = "")
+	{
+		echo "<tr><td class='label'>$label</td>";
+		text_cells(null, $name, $value, $size, $max, $title, $params, $post_label);
+
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------
+	function text_row_ex($label, $name, $size, $max = null, $title = null, $value = null, $params = null, $post_label = null)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		text_cells_ex(null, $name, $size, $max, $value, $title, $params, $post_label);
+
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------
+	function email_row($label, $name, $value, $size, $max, $title = null, $params = "", $post_label = "")
+	{
+		if (get_post($name))
+			$label = "<a href='Mailto:" . $_POST[$name] . "'>$label</a>";
+		text_row($label, $name, $value, $size, $max, $title, $params, $post_label);
+	}
+
+	function email_row_ex($label, $name, $size, $max = null, $title = null, $value = null, $params = null, $post_label = null)
+	{
+		if (get_post($name))
+			$label = "<a href='Mailto:" . $_POST[$name] . "'>$label</a>";
+		text_row_ex($label, $name, $size, $max, $title, $value, $params, $post_label);
+	}
+
+	function link_row($label, $name, $value, $size, $max, $title = null, $params = "", $post_label = "")
+	{
+		$val = get_post($name);
+		if ($val) {
+			if (strpos($val, 'http://') === false)
+				$val = 'http://' . $val;
+			$label = "<a href='$val' target='_blank'>$label</a>";
+		}
+		text_row($label, $name, $value, $size, $max, $title, $params, $post_label);
+	}
+
+	function link_row_ex($label, $name, $size, $max = null, $title = null, $value = null, $params = null, $post_label = null)
+	{
+		$val = get_post($name);
+		if ($val) {
+			if (strpos($val, 'http://') === false)
+				$val = 'http://' . $val;
+			$label = "<a href='$val' target='_blank'>$label</a>";
+		}
+		text_row_ex($label, $name, $size, $max, $title, $value, $params, $post_label);
+	}
+
+	// -----------------------------------------------------------------------------------
+	//
+	// Since FA 2.2 $init parameter is superseded by $check.
+	// When $check!=null current date is displayed in red when set to other
+	// than current date.
+	//
+	function date_cells($label, $name, $title = null, $check = null, $inc_days = 0, $inc_months = 0, $inc_years = 0, $params = null, $submit_on_change = false)
+	{
+		global $path_to_root, $Ajax;
+
+		if (! isset($_POST[$name]) || $_POST[$name] == "") {
+			if ($inc_years == 1001)
+				$_POST[$name] = null;
+			else {
+				$dd = Today();
+				if ($inc_days != 0)
+					$dd = add_days($dd, $inc_days);
+				if ($inc_months != 0)
+					$dd = add_months($dd, $inc_months);
+				if ($inc_years != 0)
+					$dd = add_years($dd, $inc_years);
+				$_POST[$name] = $dd;
+			}
+		}
+		if (user_use_date_picker()) {
+			$calc_image = (file_exists("$path_to_root/themes/" . user_theme() . "/images/cal.gif")) ? "$path_to_root/themes/" . user_theme() . "/images/cal.gif" : "$path_to_root/themes/default/images/cal.gif";
+			$post_label = "<a tabindex='-1' href=\"javascript:date_picker(document.getElementsByName('$name')[0]);\">" . "	<img src='$calc_image' width='16' height='16' border='0' alt='" . _('Click Here to Pick up the date') . "'></a>\n";
+		} else
+			$post_label = "";
+
+		if ($label != null)
+			label_cell($label, $params);
+
+		echo "<td>";
+
+		$class = $submit_on_change ? 'date active' : 'date';
+
+		$aspect = $check ? 'aspect="cdate"' : '';
+		if ($check && (get_post($name) != Today()))
+			$aspect .= ' style="color:#FF0000"';
+
+		default_focus($name);
+		$size = (user_date_format() > 3) ? 11 : 10;
+		echo "<input type=\"text\" name=\"$name\" class=\"$class\" $aspect size=\"$size\" maxlength=\"12\" value=\"" . $_POST[$name] . "\"" . ($title ? " title='$title'" : '') . " > $post_label";
+		echo "</td>\n";
+		$Ajax->addUpdate($name, $name, $_POST[$name]);
+	}
+
+	function date_row($label, $name, $title = null, $check = null, $inc_days = 0, $inc_months = 0, $inc_years = 0, $params = null, $submit_on_change = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		date_cells(null, $name, $title, $check, $inc_days, $inc_months, $inc_years, $params, $submit_on_change);
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------
+	function password_row($label, $name, $value)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		label_cell("<input type='password' name='$name' size=20 maxlength=20 value='$value' />");
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------
+	function file_cells($label, $name, $id = "")
+	{
+		if ($id != "")
+			$id = "id='$id'";
+		label_cells($label, "<input type='file' name='$name' $id />");
+	}
+
+	function file_row($label, $name, $id = "")
+	{
+		echo "<tr><td class='label'>$label</td>";
+		file_cells(null, $name, $id);
+		echo "</tr>\n";
+	}
+
+	/*-----------------------------------------------------------------------------------
+	
+	 Reference number input.
+	
+	 Optional  $context array contains transaction data used in number parsing:
+	 	'data' - data used for month/year codes
+		'location' - location code
+	 	'customer' - debtor_no
+	 	'supplier' - supplier id
+	 	'branch' - branch_code
+	*/
+	function ref_cells($label, $name, $title = null, $init = null, $params = null, $submit_on_change = false, $type = null, $context = null)
+	{
+		global $Ajax, $Refs;
+	
+		if (isset($type)) {
+			if (empty($_POST[$name.'_list'])) // restore refline id
+				$_POST[$name.'_list'] = $Refs->reflines->find_refline_id(empty($_POST[$name]) ? $init : $_POST[$name], $type);
+	
+			if (empty($_POST[$name]) || ($_SERVER['REQUEST_METHOD'] == 'GET')) // initialization
+			{
+				if (isset($init))
+				{
+					$_POST[$name] = $init;
+				} else {
+					$_POST[$name] = $Refs->get_next($type, $_POST[$name.'_list'], $context);
+				}
+				$Ajax->addUpdate(true, $name, $_POST[$name]);
+			}
+	
+			if (check_ui_refresh($name)) { // call context changed
+				$_POST[$name] = $Refs->normalize($init, $type, $context, $_POST[$name.'_list']);
+				$Ajax->addUpdate(true, $name, $_POST[$name]);
+			}
+	
+			if ($Refs->reflines->count($type)>1) {
+				if (list_updated($name.'_list')) {
+					$_POST[$name] = $Refs->get_next($type, $_POST[$name.'_list'], $context);
+					$Ajax->addUpdate(true, $name, $_POST[$name]);
+				}
+				$list = refline_list($name.'_list', $type);
+			} else {
+				$list = '';
+			}
+	
+			if (isset($label))
+				label_cell($label, $params);
+	
+			label_cell($list."<input name='".$name."' "
+				.(check_edit_access($name) ? '' : 'disabled ')
+				."value='".@$_POST[$name]."' size=10 maxlength=35>");
+		}
+		else // just wildcard ref field (e.g. for global inquires)
+		{
+			text_cells_ex($label, $name, 16, 35, $init, $title, $params, null, $submit_on_change);
+		}
+	}
+
+	// -----------------------------------------------------------------------------------
+	function ref_row($label, $name, $title = null, $init = null, $submit_on_change = false, $type=null, $context = null)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		ref_cells(null, $name, $title, $init, null, $submit_on_change, $type, $context);
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------
+	function percent_row($label, $name, $init = null)
+	{
+		if (! isset($_POST[$name]) || $_POST[$name] == "") {
+			$_POST[$name] = $init == null ? '' : $init;
+		}
+
+		small_amount_row($label, $name, $_POST[$name], null, "%", user_percent_dec());
+	}
+
+	function amount_cells_ex($label, $name, $size, $max = null, $init = null, $params = null, $post_label = null, $dec = null)
+	{
+		global $Ajax;
+
+		if (!isset($dec))
+			$dec = user_price_dec();
+		if (!isset($_POST[$name]) || $_POST[$name] == "") {
+			if ($init !== null)
+				$_POST[$name] = $init;
+			else
+				$_POST[$name] = '';
+		}
+		if ($label != null) {
+			if ($params == null)
+				$params = "class='label'";
+			label_cell($label, $params);
+		}
+		if (! isset($max))
+			$max = $size;
+
+		if ($label != null)
+			echo "<td>";
+		else
+			echo "<td align='right'>";
+
+		echo "<input class='amount' type=\"text\" name=\"$name\" size=\"$size\" maxlength=\"$max\" dec=\"$dec\" value=\"" . $_POST[$name] . "\">";
+
+		if ($post_label) {
+			echo "<span id='_{$name}_label'> $post_label</span>";
+			$Ajax->addUpdate($name, '_' . $name . '_label', $post_label);
+		}
+		echo "</td>\n";
+		$Ajax->addUpdate($name, $name, $_POST[$name]);
+		$Ajax->addAssign($name, $name, 'dec', $dec);
+	}
+
+	// -----------------------------------------------------------------------------------
+	function amount_cells($label, $name, $init = null, $params = null, $post_label = null, $dec = null)
+	{
+		amount_cells_ex($label, $name, 15, 15, $init, $params, $post_label, $dec);
+	}
+
+	// JAM Allow entered unit prices to be fractional
+	function unit_amount_cells($label, $name, $init = null, $params = null, $post_label = null, $dec = null)
+	{
+		if (! isset($dec))
+			$dec = user_price_dec() + 2;
+
+		amount_cells_ex($label, $name, 15, 15, $init, $params, $post_label, $dec + 2);
+	}
+
+	function amount_row($label, $name, $init = null, $params = null, $post_label = null, $dec = null)
+	{
+		echo "<tr>";
+		amount_cells($label, $name, $init, $params, $post_label, $dec);
+		echo "</tr>\n";
+	}
+
+	function small_amount_row($label, $name, $init = null, $params = null, $post_label = null, $dec = null)
+	{
+		echo "<tr>";
+		small_amount_cells($label, $name, $init, $params, $post_label, $dec);
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------
+	function qty_cells($label, $name, $init = null, $params = null, $post_label = null, $dec = null)
+	{
+		if (! isset($dec))
+			$dec = user_qty_dec();
+
+		amount_cells_ex($label, $name, 15, 15, $init, $params, $post_label, $dec);
+	}
+
+	function qty_row($label, $name, $init = null, $params = null, $post_label = null, $dec = null)
+	{
+		if (! isset($dec))
+			$dec = user_qty_dec();
+
+		echo "<tr>";
+		amount_cells($label, $name, $init, $params, $post_label, $dec);
+		echo "</tr>\n";
+	}
+
+	function small_qty_row($label, $name, $init = null, $params = null, $post_label = null, $dec = null)
+	{
+		if (! isset($dec))
+			$dec = user_qty_dec();
+
+		echo "<tr>";
+		small_amount_cells($label, $name, $init, $params, $post_label, $dec);
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------
+	function small_amount_cells($label, $name, $init = null, $params = null, $post_label = null, $dec = null)
+	{
+		amount_cells_ex($label, $name, 7, 12, $init, $params, $post_label, $dec);
+	}
+
+	// -----------------------------------------------------------------------------------
+	function small_qty_cells($label, $name, $init = null, $params = null, $post_label = null, $dec = null)
+	{
+		if (! isset($dec))
+			$dec = user_qty_dec();
+		amount_cells_ex($label, $name, 7, 12, $init, $params, $post_label, $dec);
+	}
+
+	// -----------------------------------------------------------------------------------
+	function textarea_cells($label, $name, $value, $cols, $rows, $title = null, $params = "")
+	{
+		global $Ajax;
+
+		default_focus($name);
+		if ($label != null)
+			echo "<td $params>$label</td>\n";
+		if ($value == null)
+			$value = (! isset($_POST[$name]) ? "" : $_POST[$name]);
+		echo "<td><textarea name='$name' cols='$cols' rows='$rows'" . ($title ? " title='$title'" : '') . ">$value</textarea></td>\n";
+		$Ajax->addUpdate($name, $name, $value);
+	}
+
+	function textarea_row($label, $name, $value, $cols, $rows, $title = null, $params = "")
+	{
+		echo "<tr><td class='label'>$label</td>";
+		textarea_cells(null, $name, $value, $cols, $rows, $title, $params);
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------
+	//
+	// When show_inactive page option is set
+	// displays value of inactive field as checkbox cell.
+	// Also updates database record after status change.
+	//
+	function inactive_control_cell($id, $value, $table, $key)
+	{
+		global $Ajax;
+
+		$name = "Inactive" . $id;
+		$value = $value ? 1 : 0;
+
+		if (check_value('show_inactive')) {
+			if (isset($_POST['LInact'][$id]) && (get_post('_Inactive' . $id . '_update') || get_post('Update')) && (check_value('Inactive' . $id) != $value)) {
+				update_record_status($id, ! $value, $table, $key);
+			}
+			echo '<td align="center">' . checkbox(null, $name, $value, true, '') . hidden("LInact[$id]", $value, false) . '</td>';
+		}
+	}
+	//
+	// Displays controls for optional display of inactive records
+	//
+	function inactive_control_row($th)
+	{
+		echo "<tr><td colspan=" . (count($th)) . ">" . "<div style='float:left;'>" . checkbox(null, 'show_inactive', null, true) . _("Show also Inactive") . "</div><div style='float:right;'>" . submit('Update', _('Update'), false, '', null) . "</div></td></tr>";
+	}
+	//
+	// Inserts additional column header when display of inactive records is on.
+	//
+	function inactive_control_column(&$th)
+	{
+		global $Ajax;
+
+		if (check_value('show_inactive'))
+			array_insert($th, count($th) - 2, _("Inactive"));
+		if (get_post('_show_inactive_update')) {
+			$Ajax->activate('_page_body');
+		}
+	}
+
+	function customer_credit_row($customer, $credit, $parms = '')
+	{
+		global $path_to_root;
+
+		label_row(_("Current Credit:"), "<a target='_blank' " . ($credit < 0 ? 'class="redfg"' : '') . "href='$path_to_root/sales/inquiry/customer_inquiry.php?customer_id=" . $customer . "'" . " onclick=\"javascript:openWindow(this.href,this.target); return false;\" >" . price_format($credit) . "</a>", $parms);
+	}
+
+	function supplier_credit_row($supplier, $credit, $parms = '')
+	{
+		global $path_to_root;
+
+		label_row(_("Current Credit:"), "<a target='_blank' " . ($credit < 0 ? 'class="redfg"' : '') . "href='$path_to_root/purchasing/inquiry/supplier_inquiry.php?supplier_id=" . $supplier . "'" . " onclick=\"javascript:openWindow(this.href,this.target); return false;\" >" . price_format($credit) . "</a>", $parms);
+	}
+
+	function bank_balance_row($bank_acc, $parms = '')
+	{
+		global $path_to_root;
+
+		$to = add_days(Today(), 1);
+		$bal = get_balance_before_for_bank_account($bank_acc, $to);
+		label_row(_("Bank Balance:"), "<a target='_blank' " . ($bal < 0 ? 'class="redfg"' : '') . "href='$path_to_root/gl/inquiry/bank_inquiry.php?bank_account=" . $bank_acc . "'" . " onclick=\"javascript:openWindow(this.href,this.target); return false;\" >&nbsp;" . price_format($bal) . "</a>", $parms);
+	}
+	
+	function ahref($label, $href, $target="", $onclick="") {
+		echo "<a href='$href' target='$target' onclick='$onclick'>$label</a>";
+	}
+	
+	function ahref_cell($label, $href, $target="", $onclick="") {
+		echo "<td align='center'>&nbsp;&nbsp;";
+		ahref($label, $href, $target, $onclick);
+		echo "&nbsp;&nbsp;</td>";
+	}
+	
+}
+
+?>

--- a/includes/ui/ListRenderer.inc
+++ b/includes/ui/ListRenderer.inc
@@ -1,0 +1,2665 @@
+<?php
+/**********************************************************************
+    Copyright (C) FrontAccounting, LLC.
+	Released under the terms of the GNU General Public License, GPL,
+	as published by the Free Software Foundation, either version 3
+	of the License, or (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the License here <http://www.gnu.org/licenses/gpl-3.0.html>.
+***********************************************************************/
+include_once ($path_to_root . "/includes/banking.inc");
+include_once ($path_to_root . "/includes/types.inc");
+include_once ($path_to_root . "/includes/current_user.inc");
+
+class ListRenderer
+{
+
+	/**
+	 *
+	 * @param ListRenderer $listRenderer
+	 * @return ListRenderer
+	 */
+	public static function get($listRenderer = null)
+	{
+		global $path_to_root;
+		static $instance = null;
+		if ($listRenderer != null) {
+			$instance = $listRenderer;
+		}
+		if ($instance == null) {
+			// Give the theme an opportunity to register a custom renderer
+			$themeName = user_theme();
+			if ($themeName) {
+				include_once ($path_to_root . "/themes/" . $themeName . "/renderer.php");
+			}
+			// Otherwise create the default renderer
+			if ($instance == null) {
+				$instance = new ListRenderer();
+			}
+		}
+		return $instance;
+	}
+
+	// ----------------------------------------------------------------------------
+	// Universal sql combo generator
+	// $sql must return selector values and selector texts in columns 0 & 1
+	// Options are merged with defaults.
+	function combo_input($name, $selected_id, $sql, $valfield, $namefield, $options = null, $type=null)
+	{
+		global $Ajax, $path_to_root, $SysPrefs;
+
+		$opts = array( // default options
+			'where' => array(), // additional constraints
+			'order' => $namefield, // list sort order
+			                       // special option parameters
+			'spec_option' => false, // option text or false
+			'spec_id' => 0, // option id
+			                // submit on select parameters
+			'default' => '', // default value when $_POST is not set
+			'multi' => false, // multiple select
+			'select_submit' => false, // submit on select: true/false
+			'async' => true, // select update via ajax (true) vs _page_body reload
+			                 // search box parameters
+			'sel_hint' => null,
+			'search_box' => false, // name or true/false
+			'type' => 0, // type of extended selector:
+			             // 0 - with (optional) visible search box, search by fragment inside id
+			             // 1 - with hidden search box, search by option text
+			             // 2 - with (optional) visible search box, search by fragment at the start of id
+			             // 3 - TODO reverse: box with hidden selector available via enter; this
+			             // would be convenient for optional ad hoc adding of new item
+			'search_submit' => true, // search submit button: true/false
+			'size' => 8, // size and max of box tag
+			'max' => 50,
+			'height' => false, // number of lines in select box
+			'cells' => false, // combo displayed as 2 <td></td> cells
+			'search' => array(), // sql field names to search
+			'format' => null, // format functions for regular options
+			'disabled' => false,
+			'box_hint' => null, // box/selectors hints; null = std see below
+			'category' => false, // category column name or false
+			'show_inactive' => false, // show inactive records.
+			'editable' => false, // false, or length of editable entry field
+			'editlink' => false	// link to entity entry/edit page (optional)
+		);
+		// ------ merge options with defaults ----------
+		if ($options != null)
+			$opts = array_merge($opts, $options);
+		if (! is_array($opts['where']))
+			$opts['where'] = array(
+				$opts['where']
+			);
+
+		$search_box = $opts['search_box'] === true ? '_' . $name . '_edit' : $opts['search_box'];
+		// select content filtered by search field:
+		$search_submit = $opts['search_submit'] === true ? '_' . $name . '_button' : $opts['search_submit'];
+		// select set by select content field
+		$search_button = $opts['editable'] ? '_' . $name . '_button' : ($search_box ? $search_submit : false);
+
+		$select_submit = $opts['select_submit'];
+		$spec_id = $opts['spec_id'];
+		$spec_option = $opts['spec_option'];
+		if ($opts['type'] == 0) {
+			$by_id = true;
+			$class = 'combo';
+		} elseif ($opts['type'] == 1) {
+			$by_id = false;
+			$class = 'combo2';
+		} else {
+			$by_id = true;
+			$class = 'combo3';
+		}
+
+		$disabled = $opts['disabled'] ? "disabled" : '';
+		$multi = $opts['multi'];
+
+		if (! count($opts['search'])) {
+			$opts['search'] = array(
+				$by_id ? $valfield : $namefield
+			);
+		}
+		if ($opts['sel_hint'] === null)
+			$opts['sel_hint'] = $by_id || $search_box == false ? '' : _('Press Space tab for search pattern entry');
+
+		if ($opts['box_hint'] === null)
+			$opts['box_hint'] = $search_box && $search_submit != false ? ($by_id ? _('Enter code fragment to search or * for all') : _('Enter description fragment to search or * for all')) : '';
+
+		if ($selected_id == null) {
+			$selected_id = get_post($name, (string) $opts['default']);
+		}
+		if (! is_array($selected_id))
+			$selected_id = array(
+				(string) $selected_id
+			); // code is generalized for multiple selection support
+
+		$txt = get_post($search_box);
+		$rel = '';
+		$limit = '';
+		if (isset($_POST['_' . $name . '_update'])) { // select list or search box change
+			if ($by_id)
+				$txt = $_POST[$name];
+
+			if (! $opts['async'])
+				$Ajax->activate('_page_body');
+			else
+				$Ajax->activate($name);
+		}
+		if (isset($_POST[$search_button])) {
+			if (! $opts['async'])
+				$Ajax->activate('_page_body');
+			else
+				$Ajax->activate($name);
+		}
+		if ($search_box) {
+			// search related sql modifications
+
+			$rel = "rel='$search_box'"; // set relation to list
+			if ($opts['search_submit']) {
+				if (isset($_POST[$search_button])) {
+					$selected_id = array(); // ignore selected_id while search
+					if (! $opts['async'])
+						$Ajax->activate('_page_body');
+					else
+						$Ajax->activate($name);
+				}
+				if ($txt == '') {
+					if ($spec_option === false && $selected_id == array())
+						$limit = ' LIMIT 1';
+					else
+						$opts['where'][] = $valfield . "=" . db_escape(get_post($name, $spec_id));
+				} else if ($txt != '*') {
+
+					foreach ($opts['search'] as $i => $s)
+						$opts['search'][$i] = $s . " LIKE " . db_escape(($class == 'combo3' ? '' : '%') . $txt . '%');
+					$opts['where'][] = '(' . implode($opts['search'], ' OR ') . ')';
+				}
+			}
+		}
+
+		// sql completion
+		if (count($opts['where'])) {
+			$where = strpos($sql, 'WHERE') == false ? ' WHERE ' : ' AND ';
+			$where .= '(' . implode($opts['where'], ' AND ') . ')';
+			$group_pos = strpos($sql, 'GROUP BY');
+			if ($group_pos) {
+				$group = substr($sql, $group_pos);
+				$sql = substr($sql, 0, $group_pos) . $where . ' ' . $group;
+			} else {
+				$sql .= $where;
+			}
+		}
+		if ($opts['order'] != false) {
+			if (! is_array($opts['order']))
+				$opts['order'] = array(
+					$opts['order']
+				);
+			$sql .= ' ORDER BY ' . implode(',', $opts['order']);
+		}
+
+		$sql .= $limit;
+		// ------ make selector ----------
+		$selector = $first_opt = '';
+		$first_id = false;
+		$found = false;
+		$lastcat = null;
+		$edit = false;
+		if ($result = db_query($sql)) {
+			while ($contact_row = db_fetch($result)) {
+				$value = $contact_row[0];
+				$descr = $opts['format'] == null ? $contact_row[1] : call_user_func($opts['format'], $contact_row);
+				$sel = '';
+				if (get_post($search_button) && ($txt == $value)) {
+					$selected_id[] = $value;
+				}
+
+				if (in_array((string) $value, $selected_id, true)) {
+					$sel = 'selected';
+					$found = $value;
+					$edit = $opts['editable'] && $contact_row['editable'] && (@$_POST[$search_box] == $value) ? $contact_row[1] : false; // get non-formatted description
+					if ($edit)
+						break; // selected field is editable - abandon list construction
+				}
+				// show selected option even if inactive
+				if (! $opts['show_inactive'] && @$contact_row['inactive'] && $sel === '') {
+					continue;
+				} else
+					$optclass = @$contact_row['inactive'] ? "class='inactive'" : '';
+
+				if ($first_id === false) {
+					$first_id = $value;
+					$first_opt = $descr;
+				}
+				$cat = $contact_row[$opts['category']];
+				if ($opts['category'] !== false && $cat != $lastcat) {
+					if ($lastcat!==null)
+						$selector .= "</optgroup>";
+					$selector .= "<optgroup label='" . $cat . "'>\n";
+					$lastcat = $cat;
+				}
+				$selector .= "<option $sel $optclass value='$value'>$descr</option>\n";
+			}
+			if ($lastcat!==null)
+				$selector .= "</optgroup>";
+			db_free_result($result);
+		}
+
+		// Prepend special option.
+		if ($spec_option !== false) { // if special option used - add it
+			$first_id = $spec_id;
+			$first_opt = $spec_option;
+			$sel = $found === false ? 'selected' : '';
+			$optclass = @$contact_row['inactive'] ? "class='inactive'" : '';
+			$selector = "<option $sel value='$first_id'>$first_opt</option>\n" . $selector;
+		}
+
+		if ($found === false) {
+			$selected_id = array(
+				$first_id
+			);
+		}
+
+		$_POST[$name] = $multi ? $selected_id : $selected_id[0];
+
+		if ($SysPrefs->use_popup_search)
+			$selector = "<select id='$name' autocomplete='off' ".($multi ? "multiple" : '')
+			. ($opts['height']!==false ? ' size="'.$opts['height'].'"' : '')
+			. "$disabled name='$name".($multi ? '[]':'')."' class='$class' title='"
+			. $opts['sel_hint']."' $rel>".$selector."</select>\n";
+		else
+			$selector = "<select autocomplete='off' ".($multi ? "multiple" : '')
+			. ($opts['height']!==false ? ' size="'.$opts['height'].'"' : '')
+			. "$disabled name='$name".($multi ? '[]':'')."' class='$class' title='"
+			. $opts['sel_hint']."' $rel>".$selector."</select>\n";
+
+		if ($by_id && ($search_box != false || $opts['editable'])) {
+			// on first display show selector list
+			if (isset($_POST[$search_box]) && $opts['editable'] && $edit) {
+				$selector = "<input type='hidden' name='$name' value='" . $_POST[$name] . "'>" . "<input type='text' $disabled name='{$name}_text' id='{$name}_text' size='" . $opts['editable'] . "' maxlength='" . $opts['max'] . "' $rel value='$edit'>\n";
+				set_focus($name . '_text'); // prevent lost focus
+			} else if (get_post($search_submit ? $search_submit : "_{$name}_button"))
+				set_focus($name); // prevent lost focus
+			if (! $opts['editable'])
+				$txt = $found;
+			$Ajax->addUpdate($name, $search_box, $txt ? $txt : '');
+		}
+
+		$Ajax->addUpdate($name, "_{$name}_sel", $selector);
+
+		// span for select list/input field update
+		$selector = "<span id='_{$name}_sel'>" . $selector . "</span>\n";
+
+		// if selectable or editable list is used - add select button
+		if ($select_submit != false || $search_button) {
+			// button class selects form reload/ajax selector update
+			$selector .= sprintf(SELECT_BUTTON, $disabled, user_theme(), (fallback_mode() ? '' : 'display:none;'), '_' . $name . '_update') . "\n";
+		}
+		// ------ make combo ----------
+		$edit_entry = '';
+		if ($search_box != false) {
+			$edit_entry = "<input $disabled type='text' name='$search_box' id='$search_box' size='" . $opts['size'] . "' maxlength='" . $opts['max'] . "' value='$txt' class='$class' rel='$name' autocomplete='off' title='" . $opts['box_hint'] . "'" . (! fallback_mode() && ! $by_id ? " style=display:none;" : '') . ">\n";
+			if ($search_submit != false || $opts['editable']) {
+				$edit_entry .= sprintf(SEARCH_BUTTON, $disabled, user_theme(), (fallback_mode() ? '' : 'display:none;'), $search_submit ? $search_submit : "_{$name}_button") . "\n";
+			}
+		}
+		default_focus(($search_box && $by_id) ? $search_box : $name);
+
+		$img = "";
+		if ($SysPrefs->use_popup_search && (!isset($opts['fixed_asset']) || !$opts['fixed_asset']))
+		{
+			$img_title = "";
+			$link = "";
+			$id = $name;
+			if ($SysPrefs->use_popup_windows) {
+				switch (strtolower($type)) {
+					case "stock":
+						$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=all&client_id=" . $id;
+						$img_title = _("Search items");
+						break;
+					case "stock_manufactured":
+						$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=manufactured&client_id=" . $id;
+						$img_title = _("Search items");
+						break;
+					case "stock_purchased":
+						$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=purchasable&client_id=" . $id;
+						$img_title = _("Search items");
+						break;
+					case "stock_sales":
+						$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=sales&client_id=" . $id;
+						$img_title = _("Search items");
+						break;
+					case "stock_costable":
+						$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=costable&client_id=" . $id;
+						$img_title = _("Search items");
+						break;
+					case "component":
+						$parent = $opts['parent'];
+						$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=component&parent=".$parent."&client_id=" . $id;
+						$img_title = _("Search items");
+						break;
+					case "kits":
+						$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=kits&client_id=" . $id;
+						$img_title = _("Search items");
+						break;
+					case "customer":
+						$link = $path_to_root . "/sales/inquiry/customers_list.php?popup=1&client_id=" . $id;
+						$img_title = _("Search customers");
+						break;
+					case "branch":
+						$link = $path_to_root . "/sales/inquiry/customer_branches_list.php?popup=1&client_id=" . $id . "#customer_id";
+						$img_title = _("Search branches");
+						break;
+					case "supplier":
+						$link = $path_to_root . "/purchasing/inquiry/suppliers_list.php?popup=1&client_id=" . $id;
+						$img_title = _("Search suppliers");
+						break;
+					case "account":
+						$link = $path_to_root . "/gl/inquiry/accounts_list.php?popup=1&client_id=" . $id;
+						$img_title = _("Search GL accounts");
+						break;
+				}
+			}
+		
+			if ($link !=="") {
+				$theme = user_theme();
+				$img = '<img src="'.$path_to_root.'/themes/'.$theme.'/images/'.ICON_VIEW.
+				'" style="vertical-align:middle;width:12px;height:12px;border:0;" onclick="javascript:lookupWindow(&quot;'.
+				$link.'&quot;, &quot;&quot;);" title="' . $img_title . '" style="cursor:pointer;" />';
+			}
+		}
+		
+		if ($opts['editlink'])
+			$selector .= ' '.$opts['editlink'];
+		
+		if ($search_box && $opts['cells'])
+			$str = ($edit_entry != '' ? "<td>$edit_entry</td>" : '') . "<td>$selector$img</td>";
+		else
+			$str = $edit_entry . $selector . $img;
+		return $str;
+	}
+
+	/*
+	 * Helper function. 
+	 * Returns true if selector $name is subject to update.
+	 */
+	function list_updated($name)
+	{
+		return isset($_POST['_' . $name . '_update']) || isset($_POST['_' . $name . '_button']);
+	}
+	// ----------------------------------------------------------------------------------------------
+	// Universal array combo generator
+	// $items is array of options 'value' => 'description'
+	// Options is reduced set of combo_selector options and is merged with defaults.
+	function array_selector($name, $selected_id, $items, $options = null)
+	{
+		global $Ajax;
+
+		$opts = array( // default options
+			'spec_option' => false, // option text or false
+			'spec_id' => 0, // option id
+			'select_submit' => false, // submit on select: true/false
+			'async' => true, // select update via ajax (true) vs _page_body reload
+			'default' => '', // default value when $_POST is not set
+			'multi' => false, // multiple select
+			                // search box parameters
+			'height' => false, // number of lines in select box
+			'sel_hint' => null,
+			'disabled' => false
+		);
+		// ------ merge options with defaults ----------
+		if ($options != null)
+			$opts = array_merge($opts, $options);
+		$select_submit = $opts['select_submit'];
+		$spec_id = $opts['spec_id'];
+		$spec_option = $opts['spec_option'];
+		$disabled = $opts['disabled'] ? "disabled" : '';
+		$multi = $opts['multi'];
+
+		if ($selected_id == null) {
+			$selected_id = get_post($name, $opts['default']);
+		}
+		if (! is_array($selected_id))
+			$selected_id = array(
+				(string) $selected_id
+			); // code is generalized for multiple selection support
+
+		if (isset($_POST['_' . $name . '_update'])) {
+			if (! $opts['async'])
+				$Ajax->activate('_page_body');
+			else
+				$Ajax->activate($name);
+		}
+
+		// ------ make selector ----------
+		$selector = $first_opt = '';
+		$first_id = false;
+		$found = false;
+		foreach ($items as $value => $descr) {
+			$sel = '';
+			if (in_array((string) $value, $selected_id, true)) {
+				$sel = 'selected';
+				$found = $value;
+			}
+			if ($first_id === false) {
+				$first_id = $value;
+				$first_opt = $descr;
+			}
+			$selector .= "<option $sel value='$value'>$descr</option>\n";
+		}
+
+		if ($first_id !== false) {
+			$sel = ($found === $first_id) || ($found === false && ($spec_option === false)) ? "selected='selected'" : '';
+		}
+		// Prepend special option.
+		if ($spec_option !== false) { // if special option used - add it
+			$first_id = $spec_id;
+			$first_opt = $spec_option;
+			$sel = $found === false ? 'selected' : '';
+			$selector = "<option $sel value='$spec_id'>$spec_option</option>\n" . $selector;
+		}
+
+		if ($found === false) {
+			$selected_id = array(
+				$first_id
+			);
+		}
+		$_POST[$name] = $multi ? $selected_id : $selected_id[0];
+
+		$selector = "<select autocomplete='off' " . ($multi ? "multiple" : '') . ($opts['height'] !== false ? ' size="' . $opts['height'] . '"' : '') . "$disabled name='$name" . ($multi ? '[]' : '') . "' class='combo' title='" . $opts['sel_hint'] . "'>" . $selector . "</select>\n";
+
+		$Ajax->addUpdate($name, "_{$name}_sel", $selector);
+
+		$selector = "<span id='_{$name}_sel'>" . $selector . "</span>\n";
+
+		if ($select_submit != false) { // if submit on change is used - add select button
+			$selector .= sprintf(SELECT_BUTTON, $disabled, user_theme(), (fallback_mode() ? '' : 'display:none;'), '_' . $name . '_update') . "\n";
+		}
+		default_focus($name);
+
+		return $selector;
+	}
+	// ----------------------------------------------------------------------------------------------
+	function array_selector_row($label, $name, $selected_id, $items, $options=null)
+	{
+		echo "<tr><td class='label'>$label</td>\n<td>";
+		echo array_selector($name, $selected_id, $items, $options);
+		echo "</td></tr>\n";
+	}
+	
+	//----------------------------------------------------------------------------------------------
+	function _format_add_curr($row)
+	{
+		static $company_currency;
+
+		if ($company_currency == null) {
+			$company_currency = get_company_currency();
+		}
+		return $row[1] . ($row[2] == $company_currency ? '' : ("&nbsp;-&nbsp;" . $row[2]));
+	}
+
+	function add_edit_combo($type)
+	{
+		global $path_to_root, $popup_editors, $SysPrefs;
+
+		if (! isset($SysPrefs->use_icon_for_editkey) || $SysPrefs->use_icon_for_editkey == 0)
+			return "";
+			// Derive theme path
+		$theme_path = $path_to_root . '/themes/' . user_theme();
+
+		$key = $popup_editors[$type][1];
+		$onclick = "onclick=\"javascript:callEditor($key); return false;\"";
+		$img = "<img width='12' height='12' border='0' alt='Add/Edit' title='Add/Edit' src='$theme_path/images/" . ICON_EDIT . "'>";
+		return "<a target = '_blank' href='#' $onclick tabindex='-1'>$img</a>";
+	}
+
+	function supplier_list($name, $selected_id = null, $spec_option = false, $submit_on_change = false, $all = false, $editkey = false)
+	{
+		$sql = "SELECT supplier_id, supp_ref, curr_code, inactive FROM " . TB_PREF . "suppliers ";
+
+		$mode = get_company_pref('no_supplier_list');
+
+		if ($editkey)
+			set_editor('supplier', $name, $editkey);
+
+		$ret = combo_input($name, $selected_id, $sql, 'supplier_id', 'supp_name', array(
+			'format' => '_format_add_curr',
+			'order' => array(
+				'supp_ref'
+			),
+			'search_box' => $mode != 0,
+			'type' => 1,
+			'search' => array(
+				"supp_ref",
+				"supp_name",
+				"gst_no"
+			),
+			'spec_option' => $spec_option === true ? _("All Suppliers") : $spec_option,
+			'spec_id' => ALL_TEXT,
+			'select_submit' => $submit_on_change,
+			'async' => false,
+			'sel_hint' => $mode ? _('Press Space tab to filter by name fragment') : _('Select supplier'),
+			'show_inactive' => $all,
+			'editlink' => $editkey ? add_edit_combo('supplier') : false
+		), "supplier");
+		return $ret;
+	}
+
+	function supplier_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $all = false, $editkey = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td><td>\n";
+		echo supplier_list($name, $selected_id, $all_option, $submit_on_change, $all, $editkey);
+		echo "</td>\n";
+	}
+
+	function supplier_list_row($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $all = false, $editkey = false)
+	{
+		echo "<tr><td class='label'>$label</td><td>";
+		echo supplier_list($name, $selected_id, $all_option, $submit_on_change, $all, $editkey);
+		echo "</td></tr>\n";
+	}
+	// ----------------------------------------------------------------------------------------------
+	function customer_list($name, $selected_id = null, $spec_option = false, $submit_on_change = false, $show_inactive = false, $editkey = false)
+	{
+		global $all_items;
+
+		$sql = "SELECT debtor_no, debtor_ref, curr_code, inactive FROM " . TB_PREF . "debtors_master ";
+
+		$mode = get_company_pref('no_customer_list');
+
+		if ($editkey)
+			set_editor('customer', $name, $editkey);
+
+		$ret = combo_input($name, $selected_id, $sql, 'debtor_no', 'debtor_ref', array(
+			'format' => '_format_add_curr',
+			'order' => array(
+				'debtor_ref'
+			),
+			'search_box' => $mode != 0,
+			'type' => 1,
+			'size' => 20,
+			'search' => array(
+				"debtor_ref",
+				"name",
+				"tax_id"
+			),
+			'spec_option' => $spec_option === true ? _("All Customers") : $spec_option,
+			'spec_id' => ALL_TEXT,
+			'select_submit' => $submit_on_change,
+			'async' => false,
+			'sel_hint' => $mode ? _('Press Space tab to filter by name fragment; F2 - entry new customer') : _('Select customer'),
+			'show_inactive' => $show_inactive,
+			'editlink' => $editkey ? add_edit_combo('customer') : false
+		), "customer" );
+		return $ret;
+	}
+
+	function customer_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $show_inactive = false, $editkey = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td nowrap>";
+		echo customer_list($name, $selected_id, $all_option, $submit_on_change, $show_inactive, $editkey);
+		echo "</td>\n";
+	}
+
+	function customer_list_row($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $show_inactive = false, $editkey = false)
+	{
+		echo "<tr><td class='label'>$label</td><td nowrap>";
+		echo customer_list($name, $selected_id, $all_option, $submit_on_change, $show_inactive, $editkey);
+		echo "</td>\n</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------------------
+	function customer_branches_list($customer_id, $name, $selected_id = null, $spec_option = true, $enabled = true, $submit_on_change = false, $editkey = false)
+	{
+		$sql = "SELECT branch_code, branch_ref FROM " . TB_PREF . "cust_branch
+		WHERE debtor_no=" . db_escape($customer_id) . " ";
+
+		if ($editkey)
+			set_editor('branch', $name, $editkey);
+
+		$where = $enabled ? array(
+			"inactive = 0"
+		) : array();
+		$ret = combo_input($name, $selected_id, $sql, 'branch_code', 'branch_ref', array(
+			'where' => $where,
+			'order' => array(
+				'branch_ref'
+			),
+			'spec_option' => $spec_option === true ? _('All branches') : $spec_option,
+			'spec_id' => ALL_TEXT,
+			'select_submit' => $submit_on_change,
+			'sel_hint' => _('Select customer branch'),
+			'editlink' => $editkey ? add_edit_combo('branch') : false
+		), "branch" );
+		return $ret;
+	}
+	// ------------------------------------------------------------------------------------------------
+	function customer_branches_list_cells($label, $customer_id, $name, $selected_id = null, $all_option = true, $enabled = true, $submit_on_change = false, $editkey = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo customer_branches_list($customer_id, $name, $selected_id, $all_option, $enabled, $submit_on_change, $editkey);
+		echo "</td>\n";
+	}
+
+	function customer_branches_list_row($label, $customer_id, $name, $selected_id = null, $all_option = true, $enabled = true, $submit_on_change = false, $editkey = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		customer_branches_list_cells(null, $customer_id, $name, $selected_id, $all_option, $enabled, $submit_on_change, $editkey);
+		echo "</tr>";
+	}
+
+	// ------------------------------------------------------------------------------------------------
+	function locations_list($name, $selected_id = null, $all_option = false, $submit_on_change = false, $fixed_asset = false)
+	{
+		$sql = "SELECT loc_code, location_name, inactive FROM ".TB_PREF."locations WHERE fixed_asset=".(int)$fixed_asset;
+	
+		return combo_input($name, $selected_id, $sql, 'loc_code', 'location_name',
+			array(
+				'spec_option' => $all_option === true ? _("All Locations") : $all_option,
+				'spec_id' => ALL_TEXT,
+				'select_submit'=> $submit_on_change
+			));
+	}
+
+	function locations_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $fixed_asset = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo locations_list($name, $selected_id, $all_option, $submit_on_change, $fixed_asset);
+		echo "</td>\n";
+	}
+
+	function locations_list_row($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $fixed_asset = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		locations_list_cells(null, $name, $selected_id, $all_option, $submit_on_change, $fixed_asset);
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------------------
+	function currencies_list($name, $selected_id = null, $submit_on_change = false, $exclude_home_curr = false)
+	{
+		$sql = "SELECT curr_abrev, currency, inactive FROM " . TB_PREF . "currencies";
+		if ($exclude_home_curr)
+			$sql .= " WHERE curr_abrev!='".get_company_currency()."'";
+		
+		// default to the company currency
+		return combo_input($name, $selected_id, $sql, 'curr_abrev', 'currency', array(
+			'select_submit' => $submit_on_change,
+			'default' => get_company_currency(),
+			'async' => false
+		));
+	}
+
+	function currencies_list_cells($label, $name, $selected_id = null, $submit_on_change = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo currencies_list($name, $selected_id, $submit_on_change);
+		echo "</td>\n";
+	}
+
+	function currencies_list_row($label, $name, $selected_id = null, $submit_on_change = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		currencies_list_cells(null, $name, $selected_id, $submit_on_change);
+		echo "</tr>\n";
+	}
+
+	// ---------------------------------------------------------------------------------------------------
+	function fiscalyears_list($name, $selected_id = null, $submit_on_change = false)
+	{
+		$sql = "SELECT * FROM " . TB_PREF . "fiscal_year";
+
+		// default to the company current fiscal year
+
+		return combo_input($name, $selected_id, $sql, 'id', '', array(
+			'order' => 'begin',
+			'default' => get_company_pref('f_year'),
+			'format' => '_format_fiscalyears',
+			'select_submit' => $submit_on_change,
+			'async' => false
+		));
+	}
+
+	function _format_fiscalyears($row)
+	{
+		return sql2date($row[1]) . "&nbsp;-&nbsp;" . sql2date($row[2]) . "&nbsp;&nbsp;" . ($row[3] ? _('Closed') : _('Active')) . "</option>\n";
+	}
+
+	function fiscalyears_list_cells($label, $name, $selected_id = null)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo fiscalyears_list($name, $selected_id);
+		echo "</td>\n";
+	}
+
+	function fiscalyears_list_row($label, $name, $selected_id = null)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		fiscalyears_list_cells(null, $name, $selected_id);
+		echo "</tr>\n";
+	}
+	// ------------------------------------------------------------------------------------
+	function dimensions_list($name, $selected_id = null, $no_option = false, $showname = ' ', $submit_on_change = false, $showclosed = false, $showtype = 1)
+	{
+		$sql = "SELECT id, CONCAT(reference,'  ',name) as ref FROM " . TB_PREF . "dimensions";
+
+		$options = array(
+			'order' => 'reference',
+			'spec_option' => $no_option ? $showname : false,
+			'spec_id' => 0,
+			'select_submit' => $submit_on_change,
+			'async' => false
+		);
+
+		if (! $showclosed)
+			$options['where'][] = "closed=0";
+		if ($showtype)
+			$options['where'][] = "type_=" . db_escape($showtype);
+
+		return combo_input($name, $selected_id, $sql, 'id', 'ref', $options);
+	}
+
+	function dimensions_list_cells($label, $name, $selected_id = null, $no_option = false, $showname = null, $showclosed = false, $showtype = 0, $submit_on_change = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo dimensions_list($name, $selected_id, $no_option, $showname, $submit_on_change, $showclosed, $showtype);
+		echo "</td>\n";
+	}
+
+	function dimensions_list_row($label, $name, $selected_id = null, $no_option = false, $showname = null, $showclosed = false, $showtype = 0, $submit_on_change = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		dimensions_list_cells(null, $name, $selected_id, $no_option, $showname, $showclosed, $showtype, $submit_on_change);
+		echo "</tr>\n";
+	}
+
+	// ---------------------------------------------------------------------------------------------------
+	function stock_items_list($name, $selected_id = null, $all_option = false, $submit_on_change = false, $opts = array(), $editkey = false, $type = "stock")
+	{
+		global $all_items;
+
+		$sql = "SELECT stock_id, s.description, c.description, s.inactive, s.editable
+			FROM " . TB_PREF . "stock_master s," . TB_PREF . "stock_category c WHERE s.category_id=c.category_id";
+		if (isset($opts['fixed_asset']) && $opts['fixed_asset'])
+			$sql .= " AND mb_flag='F'";
+		else
+			$sql .= " AND mb_flag!='F'";
+		
+		if ($editkey)
+			set_editor('item', $name, $editkey);
+
+		$ret = combo_input($name, $selected_id, $sql, 'stock_id', 's.description', array_merge(array(
+			'format' => '_format_stock_items',
+			'spec_option' => $all_option === true ? _("All Items") : $all_option,
+			'spec_id' => ALL_TEXT,
+			'search_box' => true,
+			'search' => array(
+				"stock_id",
+				"c.description",
+				"s.description"
+			),
+			'search_submit' => get_company_pref('no_item_list') != 0,
+			'size' => 10,
+			'select_submit' => $submit_on_change,
+			'category' => 2,
+			'order' => array(
+				'c.description',
+				'stock_id'
+			),
+			'editlink' => $editkey ? add_edit_combo('item') : false,
+			'editable' => false,
+			'max' => 255
+		), $opts), $type);
+		return $ret;
+	}
+
+	function _format_stock_items($row)
+	{
+		return (user_show_codes() ? ($row[0] . "&nbsp;-&nbsp;") : "") . $row[1];
+	}
+
+	function stock_items_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $all = false, $editkey = false, $opts= array())
+	{
+		if (isset($opts['fixed_asset']) && $opts['fixed_asset'])
+			$editor_item = 'fa_item';
+		else
+			$editor_item = 'item';
+	
+	// 	if ($editkey) ??
+	//		set_editor($editor_item, $name, $editkey);
+	
+		if ($label != null)
+			echo "<td>$label</td>\n";
+	
+	// ??
+	//  $opts = array_merge($options, array('cells'=>true, 'show_inactive'=>$all, 'new_icon' => $editkey ? 'item' : false));
+	//
+	//	echo stock_items_list($name, $selected_id, $all_option, $submit_on_change, $opts);
+	
+		echo stock_items_list(
+			$name, $selected_id, $all_option, $submit_on_change,
+			array_merge(array('cells' => true, 'show_inactive' => $all), $opts), $editkey
+		);
+		
+	}
+	/*
+	 * function stock_items_list_row($label, $name, $selected_id=null, $all_option=false, $submit_on_change=false) {
+	 * echo "<tr>\n"; stock_items_list_cells($label, $name, $selected_id, $all_option, $submit_on_change); echo
+	 * "</tr>\n"; }
+	 */
+	// ---------------------------------------------------------------------------------------------------
+	//
+	// Select item via foreign code.
+	//
+	function sales_items_list($name, $selected_id = null, $all_option = false, $submit_on_change = false, $type = '', $opts = array())
+	{
+		// all sales codes
+		$sql = "SELECT i.item_code, i.description, c.description, count(*)>1 as kit,
+			 i.inactive, if(count(*)>1, '0', s.editable) as editable
+			FROM
+			" . TB_PREF . "stock_master s,
+			" . TB_PREF . "item_codes i
+			LEFT JOIN
+			" . TB_PREF . "stock_category c
+			ON i.category_id=c.category_id
+			WHERE i.stock_id=s.stock_id
+			AND mb_flag != 'F'";
+
+		if ($type == 'local') { // exclude foreign codes
+			$sql .= " AND !i.is_foreign";
+		} elseif ($type == 'kits') { // sales kits
+			$sql .= " AND !i.is_foreign AND i.item_code!=i.stock_id";
+		}
+		$sql .= " AND !i.inactive AND !s.inactive AND !s.no_sale";
+		$sql .= " GROUP BY i.item_code";
+
+		return combo_input($name, $selected_id, $sql, 'i.item_code', 'c.description', array_merge(array(
+			'format' => '_format_stock_items',
+			'spec_option' => $all_option === true ? _("All Items") : $all_option,
+			'spec_id' => ALL_TEXT,
+			'search_box' => true,
+			'search' => array(
+				"i.item_code",
+				"c.description",
+				"i.description"
+			),
+			'search_submit' => get_company_pref('no_item_list') != 0,
+			'size' => 15,
+			'select_submit' => $submit_on_change,
+			'category' => 2,
+			'order' => array(
+				'c.description',
+				'i.item_code'
+			),
+			'editable' => 30,
+			'max' => 255
+		), $opts), $type == 'kits' ? $type : "stock_sales");
+	}
+
+	function sales_items_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $editkey = false)
+	{
+		if ($editkey)
+			set_editor('item', $name, $editkey);
+
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo sales_items_list($name, $selected_id, $all_option, $submit_on_change, '', array(
+			'cells' => true
+		));
+	}
+
+	function sales_kits_list($name, $selected_id = null, $all_option = false, $submit_on_change = false)
+	{
+		return sales_items_list($name, $selected_id, $all_option, $submit_on_change, 'kits', array(
+			'cells' => false,
+			'editable' => false
+		));
+	}
+
+	function sales_local_items_list_row($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false)
+	{
+		echo "<tr>";
+		if ($label != null)
+			echo "<td class='label'>$label</td>\n";
+		echo "<td>";
+		echo sales_items_list($name, $selected_id, $all_option, $submit_on_change, 'local', array(
+			'cells' => false,
+			'editable' => false
+		));
+		echo "</td></tr>";
+	}
+	// ------------------------------------------------------------------------------------
+	function stock_manufactured_items_list($name, $selected_id = null, $all_option = false, $submit_on_change = false)
+	{
+		return stock_items_list($name, $selected_id, $all_option, $submit_on_change, array(
+			'where' => array(
+				"mb_flag= 'M'"
+			)
+		), false, "stock_manufactured");
+	}
+
+	function stock_manufactured_items_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo stock_manufactured_items_list($name, $selected_id, $all_option, $submit_on_change);
+		echo "</td>\n";
+	}
+
+	function stock_manufactured_items_list_row($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		stock_manufactured_items_list_cells(null, $name, $selected_id, $all_option, $submit_on_change);
+		echo "</tr>\n";
+	}
+	// ------------------------------------------------------------------------------------
+	function stock_component_items_list($name, $parent_stock_id, $selected_id = null, $all_option = false, $submit_on_change = false, $editkey = false)
+	{
+		$parent = db_escape($parent_stock_id);
+		return stock_items_list($name, $selected_id, $all_option, $submit_on_change, array(
+			'where' => array(
+				"stock_id != $parent"
+			),
+			'parent' => $parent_stock_id
+		), $editkey, "component");
+	}
+
+	function stock_component_items_list_cells($label, $name, $parent_stock_id, $selected_id = null, $all_option = false, $submit_on_change = false, $editkey = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		$parent = db_escape($parent_stock_id);
+		echo stock_items_list($name, $selected_id, $all_option, $submit_on_change, array(
+			'where' => array(
+				"stock_id != '$parent_stock_id'"
+			),
+			'cells' => true,
+			'parent'=> $parent_stock_id
+		), $editkey, "component");
+	}
+	// ------------------------------------------------------------------------------------
+	function stock_costable_items_list($name, $selected_id = null, $all_option = false, $submit_on_change = false)
+	{
+		return stock_items_list($name, $selected_id, $all_option, $submit_on_change, array(
+			'where' => array(
+				"mb_flag!='D'"
+			)
+		), false, "stock_costable");
+	}
+
+	function stock_costable_items_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo stock_items_list($name, $selected_id, $all_option, $submit_on_change, array(
+			'where' => array(
+				"mb_flag!='D'"
+			),
+			'cells' => true
+		), false, "stock_costable");
+	}
+
+	// ------------------------------------------------------------------------------------
+	function stock_purchasable_items_list($name, $selected_id = null, $all_option = false, $submit_on_change = false, $all = false, $editkey = false)
+	{
+		return stock_items_list($name, $selected_id, $all_option, $submit_on_change, array(
+			'where' => array(
+				"NOT no_purchase"
+			),
+			'show_inactive' => $all
+		), $editkey, "stock_purchased");
+	}
+	//
+	// This helper is used in PO/GRN/PI entry and supports editable descriptions.
+	//
+	function stock_purchasable_items_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $editkey = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo stock_items_list($name, $selected_id, $all_option, $submit_on_change, array(
+			'where' => array(
+				"NOT no_purchase"
+			),
+			'editable' => 30,
+			'cells' => true
+		), $editkey, "stock_purchased"); // REVIEW: "stock_purchased" not in unstable CP 2016-01 
+	}
+	// ------------------------------------------------------------------------------------
+	function stock_item_types_list_row($label, $name, $selected_id = null, $enabled = true)
+	{
+		global $stock_types;
+
+		echo "<tr>";
+		if ($label != null)
+			echo "<td class='label'>$label</td>\n";
+		echo "<td>";
+
+		echo array_selector($name, $selected_id, $stock_types, array(
+			'select_submit' => true,
+			'disabled' => ! $enabled
+		));
+		echo "</td></tr>\n";
+	}
+
+	function stock_units_list_row($label, $name, $value = null, $enabled = true)
+	{
+		$result = get_all_item_units();
+		echo "<tr>";
+		if ($label != null)
+			echo "<td class='label'>$label</td>\n";
+		echo "<td>";
+
+		while ($unit = db_fetch($result))
+			$units[$unit['abbr']] = $unit['name'];
+
+		echo array_selector($name, $value, $units, array(
+			'disabled' => ! $enabled
+		));
+
+		echo "</td></tr>\n";
+	}
+
+	function stock_purchasable_fa_list_cells($label, $name, $selected_id=null, $all_option=false,
+		$submit_on_change=false, $all=false, $editkey = false, $exclude_items = array())
+	{
+		// Check if a fixed asset has been bought.
+		$where_opts[] = "stock_id NOT IN
+		( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE type=".ST_SUPPRECEIVE." AND qty!=0 )";
+	
+		// exclude items currently on the order.
+		foreach($exclude_items as $item) {
+			$where_opts[] = "stock_id != ".db_escape($item->stock_id);
+		}
+		$where_opts[] = "mb_flag='F'";
+	
+		echo stock_items_list_cells($label, $name, $selected_id, $all_option, $submit_on_change, $all, $editkey,
+			array('fixed_asset' => true, 'where' => $where_opts));
+	}
+	
+	function stock_disposable_fa_list($name, $selected_id=null,
+		$all_option=false, $submit_on_change=false)
+	{
+		// Check if a fixed asset has been bought....
+		$where_opts[] = "stock_id IN
+		( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE type=".ST_SUPPRECEIVE." AND qty!=0 )";
+		// ...but has not been disposed or sold already.
+		$where_opts[] = "stock_id NOT IN
+		( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE (type=".ST_CUSTDELIVERY." OR type=".ST_INVADJUST.") AND qty!=0 )";
+	
+		$where_opts[] = "mb_flag='F'";
+	
+		echo stock_items_list($name, $selected_id, $all_option, $submit_on_change,
+			array('fixed_asset' => true, 'where' => $where_opts));
+	}
+	
+	function stock_disposable_fa_list_cells($label, $name, $selected_id=null,
+		$all_option=false, $submit_on_change=false, $exclude_items = array())
+	{
+		// Check if a fixed asset has been bought....
+		$where_opts[] = "stock_id IN
+		( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE type=".ST_SUPPRECEIVE." AND qty!=0 )";
+		// ...but has not been disposed or sold already.
+		$where_opts[] = "stock_id NOT IN
+		( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE (type=".ST_CUSTDELIVERY." OR type=".ST_INVADJUST.") AND qty!=0 )";
+	
+		$where_opts[] = "mb_flag='F'";
+	
+		foreach($exclude_items as $item) {
+			$where_opts[] = "stock_id != ".db_escape($item->stock_id);
+		}
+	
+		if ($label != null)
+			echo "<td>$label</td>\n";
+			echo stock_items_list($name, $selected_id, $all_option, $submit_on_change,
+				array('fixed_asset' => true, 'cells'=>true, 'where' => $where_opts));
+	}
+	
+	function stock_depreciable_fa_list_cells($label, $name, $selected_id=null,
+		$all_option=false, $submit_on_change=false)
+	{
+	
+		// Check if a fixed asset has been bought....
+		$where_opts[] = "stock_id IN
+		( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE type=".ST_SUPPRECEIVE." AND qty!=0 )";
+		// ...but has not been disposed or sold already.
+		$where_opts[] = "stock_id NOT IN
+		( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE (type=".ST_CUSTDELIVERY." OR type=".ST_INVADJUST.") AND qty!=0 )";
+	
+		$year = get_current_fiscalyear();
+		$y = date('Y', strtotime($year['end']));
+	
+		// check if current fiscal year
+		$where_opts[] = "depreciation_date < '".$y."-12-01'";
+		$where_opts[] = "depreciation_date >= '".($y-1)."-12-01'";
+	
+		$where_opts[] = "material_cost > 0";
+		$where_opts[] = "mb_flag='F'";
+	
+		if ($label != null)
+			echo "<td>$label</td>\n";
+			echo stock_items_list($name, $selected_id, $all_option, $submit_on_change,
+			 array('fixed_asset' => true, 'where' => $where_opts, 'cells'=>true));
+	}
+	
+	// ------------------------------------------------------------------------------------
+	function tax_types_list($name, $selected_id = null, $none_option = false, $submit_on_change = false)
+	{
+		$sql = "SELECT id, CONCAT(name, ' (',rate,'%)') as name FROM " . TB_PREF . "tax_types";
+
+		return combo_input($name, $selected_id, $sql, 'id', 'name', array(
+			'spec_option' => $none_option,
+			'spec_id' => ALL_NUMERIC,
+			'select_submit' => $submit_on_change,
+			'async' => false
+		));
+	}
+
+	function tax_types_list_cells($label, $name, $selected_id = null, $none_option = false, $submit_on_change = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo tax_types_list($name, $selected_id, $none_option, $submit_on_change);
+		echo "</td>\n";
+	}
+
+	function tax_types_list_row($label, $name, $selected_id = null, $none_option = false, $submit_on_change = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		tax_types_list_cells(null, $name, $selected_id, $none_option, $submit_on_change);
+		echo "</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------
+	function tax_groups_list($name, $selected_id = null, $none_option = false, $submit_on_change = false)
+	{
+		$sql = "SELECT id, name FROM " . TB_PREF . "tax_groups";
+
+		return combo_input($name, $selected_id, $sql, 'id', 'name', array(
+			'order' => 'id',
+			'spec_option' => $none_option,
+			'spec_id' => ALL_NUMERIC,
+			'select_submit' => $submit_on_change,
+			'async' => false
+		));
+	}
+
+	function tax_groups_list_cells($label, $name, $selected_id = null, $none_option = false, $submit_on_change = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo tax_groups_list($name, $selected_id, $none_option, $submit_on_change);
+		echo "</td>\n";
+	}
+
+	function tax_groups_list_row($label, $name, $selected_id = null, $none_option = false, $submit_on_change = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		tax_groups_list_cells(null, $name, $selected_id, $none_option, $submit_on_change);
+		echo "</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------
+	function item_tax_types_list($name, $selected_id = null)
+	{
+		$sql = "SELECT id, name FROM " . TB_PREF . "item_tax_types";
+		return combo_input($name, $selected_id, $sql, 'id', 'name', array(
+			'order' => 'id'
+		));
+	}
+
+	function item_tax_types_list_cells($label, $name, $selected_id = null)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo item_tax_types_list($name, $selected_id);
+		echo "</td>\n";
+	}
+
+	function item_tax_types_list_row($label, $name, $selected_id = null)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		item_tax_types_list_cells(null, $name, $selected_id);
+		echo "</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------
+	function shippers_list($name, $selected_id = null)
+	{
+		$sql = "SELECT shipper_id, shipper_name, inactive FROM " . TB_PREF . "shippers";
+		return combo_input($name, $selected_id, $sql, 'shipper_id', 'shipper_name', array(
+			'order' => array(
+				'shipper_name'
+			)
+		));
+	}
+
+	function shippers_list_cells($label, $name, $selected_id = null)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo shippers_list($name, $selected_id);
+		echo "</td>\n";
+	}
+
+	function shippers_list_row($label, $name, $selected_id = null)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		shippers_list_cells(null, $name, $selected_id);
+		echo "</tr>\n";
+	}
+
+	// -------------------------------------------------------------------------------------
+	function sales_persons_list($name, $selected_id = null, $spec_opt = false)
+	{
+		$sql = "SELECT salesman_code, salesman_name, inactive FROM " . TB_PREF . "salesman";
+		return combo_input($name, $selected_id, $sql, 'salesman_code', 'salesman_name', array(
+			'order' => array(
+				'salesman_name'
+			),
+			'spec_option' => $spec_opt,
+			'spec_id' => ALL_NUMERIC
+		));
+	}
+
+	function sales_persons_list_cells($label, $name, $selected_id = null, $spec_opt = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>\n";
+		echo sales_persons_list($name, $selected_id, $spec_opt);
+		echo "</td>\n";
+	}
+
+	function sales_persons_list_row($label, $name, $selected_id = null, $spec_opt = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		sales_persons_list_cells(null, $name, $selected_id, $spec_opt);
+		echo "</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------
+	function sales_areas_list($name, $selected_id = null)
+	{
+		$sql = "SELECT area_code, description, inactive FROM " . TB_PREF . "areas";
+		return combo_input($name, $selected_id, $sql, 'area_code', 'description', array());
+	}
+
+	function sales_areas_list_cells($label, $name, $selected_id = null)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo sales_areas_list($name, $selected_id);
+		echo "</td>\n";
+	}
+
+	function sales_areas_list_row($label, $name, $selected_id = null)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		sales_areas_list_cells(null, $name, $selected_id);
+		echo "</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------
+	function sales_groups_list($name, $selected_id = null, $special_option = false)
+	{
+		$sql = "SELECT id, description, inactive FROM " . TB_PREF . "groups";
+		return combo_input($name, $selected_id, $sql, 'id', 'description', array(
+			'spec_option' => $special_option === true ? ' ' : $special_option,
+			'order' => 'description',
+			'spec_id' => 0
+		));
+	}
+
+	function sales_groups_list_cells($label, $name, $selected_id = null, $special_option = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo sales_groups_list($name, $selected_id, $special_option);
+		echo "</td>\n";
+	}
+
+	function sales_groups_list_row($label, $name, $selected_id = null, $special_option = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		sales_groups_list_cells(null, $name, $selected_id, $special_option);
+		echo "</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------
+	function _format_template_items($row)
+	{
+		return ($row[0] . "&nbsp;- &nbsp;" . _("Amount") . "&nbsp;" . $row[1]);
+	}
+
+	function templates_list($name, $selected_id = null, $special_option = false)
+	{
+		$sql = "SELECT sorder.order_no,	Sum(line.unit_price*line.quantity*(1-line.discount_percent)) AS OrderValue
+		FROM " . TB_PREF . "sales_orders as sorder, " . TB_PREF . "sales_order_details as line
+		WHERE sorder.order_no = line.order_no AND sorder.type = 1 GROUP BY line.order_no";
+		return combo_input($name, $selected_id, $sql, 'order_no', 'OrderValue', array(
+			'format' => '_format_template_items',
+			'spec_option' => $special_option === true ? ' ' : $special_option,
+			'order' => 'order_no',
+			'spec_id' => 0
+		));
+	}
+
+	function templates_list_cells($label, $name, $selected_id = null, $special_option = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo templates_list($name, $selected_id, $special_option);
+		echo "</td>\n";
+	}
+
+	function templates_list_row($label, $name, $selected_id = null, $special_option = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		templates_list_cells(null, $name, $selected_id, $special_option);
+		echo "</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------
+	function workorders_list($name, $selected_id = null)
+	{
+		$sql = "SELECT id, wo_ref FROM " . TB_PREF . "workorders WHERE closed=0";
+		return combo_input($name, $selected_id, $sql, 'id', 'wo_ref', array());
+	}
+
+	function workorders_list_cells($label, $name, $selected_id = null)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo workorders_list($name, $selected_id);
+		echo "</td>\n";
+	}
+
+	function workorders_list_row($label, $name, $selected_id = null)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		workorders_list_cells(null, $name, $selected_id);
+		echo "</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------
+	function payment_terms_list($name, $selected_id = null)
+	{
+		$sql = "SELECT terms_indicator, terms, inactive FROM " . TB_PREF . "payment_terms";
+		return combo_input($name, $selected_id, $sql, 'terms_indicator', 'terms', array());
+	}
+
+	function payment_terms_list_cells($label, $name, $selected_id = null)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo payment_terms_list($name, $selected_id);
+		echo "</td>\n";
+	}
+
+	function payment_terms_list_row($label, $name, $selected_id = null)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		payment_terms_list_cells(null, $name, $selected_id);
+		echo "</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------
+	function credit_status_list($name, $selected_id = null)
+	{
+		$sql = "SELECT id, reason_description, inactive FROM " . TB_PREF . "credit_status";
+		return combo_input($name, $selected_id, $sql, 'id', 'reason_description', array());
+	}
+
+	function credit_status_list_cells($label, $name, $selected_id = null)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo credit_status_list($name, $selected_id);
+		echo "</td>\n";
+	}
+
+	function credit_status_list_row($label, $name, $selected_id = null)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		credit_status_list_cells(null, $name, $selected_id);
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------------------
+	function sales_types_list($name, $selected_id = null, $submit_on_change = false, $special_option = false)
+	{
+		$sql = "SELECT id, sales_type, inactive FROM " . TB_PREF . "sales_types";
+
+		return combo_input($name, $selected_id, $sql, 'id', 'sales_type', array(
+			'spec_option' => $special_option === true ? _("All Sales Types") : $special_option,
+			'spec_id' => 0,
+			'select_submit' => $submit_on_change
+		));
+	}
+
+	function sales_types_list_cells($label, $name, $selected_id = null, $submit_on_change = false, $special_option = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo sales_types_list($name, $selected_id, $submit_on_change, $special_option);
+		echo "</td>\n";
+	}
+
+	function sales_types_list_row($label, $name, $selected_id = null, $submit_on_change = false, $special_option = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		sales_types_list_cells(null, $name, $selected_id, $submit_on_change, $special_option);
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------------------
+
+	function _format_date($row)
+	{
+		return sql2date($row['reconciled']);
+	}
+
+	function bank_reconciliation_list($account, $name, $selected_id = null, $submit_on_change = false, $special_option = false)
+	{
+		$sql = "SELECT reconciled, reconciled FROM " . TB_PREF . "bank_trans
+		WHERE bank_act=" . db_escape($account) . " AND reconciled IS NOT NULL
+		GROUP BY reconciled";
+		return combo_input($name, $selected_id, $sql, 'id', 'reconciled', array(
+			'spec_option' => $special_option,
+			'format' => '_format_date',
+			'spec_id' => '',
+			'select_submit' => $submit_on_change
+		));
+	}
+
+	function bank_reconciliation_list_cells($label, $account, $name, $selected_id = null, $submit_on_change = false, $special_option = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo bank_reconciliation_list($account, $name, $selected_id, $submit_on_change, $special_option);
+		echo "</td>\n";
+	}
+	/*
+	function bank_reconciliation_list_row($label, $account, $name, $selected_id=null, $submit_on_change=false, $special_option=false)
+	{
+		echo "<tr>\n";
+		bank_reconciliation_list_cells($label, $account, $name, $selected_id, $submit_on_change, $special_option);
+		echo "</tr>\n";
+	}
+	*/
+	// -----------------------------------------------------------------------------------------------
+	function workcenter_list($name, $selected_id = null, $all_option = false)
+	{
+		$sql = "SELECT id, name, inactive FROM " . TB_PREF . "workcentres";
+
+		return combo_input($name, $selected_id, $sql, 'id', 'name', array(
+			'spec_option' => $all_option === true ? _("All Suppliers") : $all_option,
+			'spec_id' => ALL_TEXT
+		));
+	}
+
+	function workcenter_list_cells($label, $name, $selected_id = null, $all_option = false)
+	{
+		default_focus($name);
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo workcenter_list($name, $selected_id, $all_option);
+		echo "</td>\n";
+	}
+
+	function workcenter_list_row($label, $name, $selected_id = null, $all_option = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		workcenter_list_cells(null, $name, $selected_id, $all_option);
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------------------
+	function bank_accounts_list($name, $selected_id = null, $submit_on_change = false, $spec_option = false)
+	{
+		$sql = "SELECT id, bank_account_name, bank_curr_code, inactive
+				FROM " . TB_PREF . "bank_accounts";
+
+		return combo_input($name, $selected_id, $sql, 'id', 'bank_account_name', array(
+			'format' => '_format_add_curr',
+			'select_submit' => $submit_on_change,
+			'spec_option' => $spec_option,
+			'spec_id' => '',
+			'async' => false
+		));
+	}
+
+	function bank_accounts_list_cells($label, $name, $selected_id = null, $submit_on_change = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo bank_accounts_list($name, $selected_id, $submit_on_change);
+		echo "</td>\n";
+	}
+
+	function bank_accounts_list_row($label, $name, $selected_id = null, $submit_on_change = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		bank_accounts_list_cells(null, $name, $selected_id, $submit_on_change);
+		echo "</tr>\n";
+	}
+	// -----------------------------------------------------------------------------------------------
+	function cash_accounts_list_row($label, $name, $selected_id = null, $submit_on_change = false)
+	{
+		$sql = "SELECT id, bank_account_name, bank_curr_code, inactive
+			FROM ".TB_PREF."bank_accounts
+			WHERE account_type=".BT_CASH;
+	
+		if ($label != null)
+			echo "<tr><td class='label'>$label</td>\n";
+		echo "<td>";
+		echo combo_input($name, $selected_id, $sql, 'id', 'bank_account_name',
+			array(
+				'spec_option' => $all_option,
+				'spec_id' => ALL_TEXT,
+				'format' => '_format_add_curr',
+				'select_submit'=> $submit_on_change,
+				'async' => true
+			) );
+		echo "</td></tr>\n";
+	}
+	// -----------------------------------------------------------------------------------------------
+	function pos_list_row($label, $name, $selected_id = null, $spec_option = false, $submit_on_change = false)
+	{
+		$sql = "SELECT id, pos_name, inactive FROM " . TB_PREF . "sales_pos";
+
+		default_focus($name);
+		echo '<tr>';
+		if ($label != null)
+			echo "<td class='label'>$label</td>\n";
+		echo "<td>";
+
+		echo combo_input($name, $selected_id, $sql, 'id', 'pos_name', array(
+			'select_submit' => $submit_on_change,
+			'async' => true,
+			'spec_option' => $spec_option,
+			'spec_id' => - 1,
+			'order' => array(
+				'pos_name'
+			)
+		));
+		echo "</td></tr>\n";
+	}
+	// -----------------------------------------------------------------------------------------------
+	// Payment type selector for current user.
+	//
+	function sale_payment_list($name, $category, $selected_id = null, $submit_on_change = true, $prepayments = true)
+	{
+		$sql = "SELECT terms_indicator, terms, inactive FROM ".TB_PREF."payment_terms";
+	
+		if ($category == PM_CASH) // only cash
+			$sql .= " WHERE days_before_due=0 AND day_in_following_month=0";
+		elseif ($category == PM_CREDIT) // only delayed payments
+			$sql .= " WHERE days_before_due".($prepayments ? '!=': '>')."0 OR day_in_following_month!=0";
+		elseif (!$prepayments)
+			$sql .= " WHERE days_before_due>=0";
+	
+		return combo_input($name, $selected_id, $sql, 'terms_indicator', 'terms',
+			array(
+				'select_submit'=> $submit_on_change,
+				'async' => true
+			)
+		);
+	
+	}
+
+	function sale_payment_list_cells($label, $name, $category, $selected_id = null, $submit_on_change = true, $prepayments = true)
+	{
+		if ($label != null)
+			echo "<td class='label'>$label</td>\n";
+		echo "<td>";
+
+		echo sale_payment_list($name, $category, $selected_id, $submit_on_change, $prepayments);
+
+		echo "</td>\n";
+	}
+	// -----------------------------------------------------------------------------------------------
+	function class_list($name, $selected_id = null, $submit_on_change = false)
+	{
+		$sql = "SELECT cid, class_name FROM " . TB_PREF . "chart_class";
+
+		return combo_input($name, $selected_id, $sql, 'cid', 'class_name', array(
+			'select_submit' => $submit_on_change,
+			'async' => false
+		));
+	}
+
+	function class_list_cells($label, $name, $selected_id = null, $submit_on_change = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo class_list($name, $selected_id, $submit_on_change);
+		echo "</td>\n";
+	}
+
+	function class_list_row($label, $name, $selected_id = null, $submit_on_change = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		class_list_cells(null, $name, $selected_id, $submit_on_change);
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------------------
+	function stock_categories_list($name, $selected_id=null, $spec_opt=false, $submit_on_change=false, $fixed_asset = false)
+	{
+		$where_opts = array();
+		if ($fixed_asset)
+			$where_opts[0] = "dflt_mb_flag='F'";
+		else
+			$where_opts[0] = "dflt_mb_flag!='F'";
+	
+		$sql = "SELECT category_id, description, inactive FROM ".TB_PREF."stock_category";
+		return combo_input($name, $selected_id, $sql, 'category_id', 'description',
+	 		array('order'=>'category_id',
+				'spec_option' => $spec_opt,
+				'spec_id' => -1,
+	 			'select_submit'=> $submit_on_change,
+	 			'async' => true,
+				'where' => $where_opts,
+	 		)
+		);
+	}
+	
+	function stock_categories_list_cells($label, $name, $selected_id = null, $spec_opt = false, $submit_on_change = false, $fixed_asset = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo stock_categories_list($name, $selected_id, $spec_opt, $submit_on_change, $fixed_asset);
+		echo "</td>\n";
+	}
+
+	function stock_categories_list_row($label, $name, $selected_id = null, $spec_opt = false, $submit_on_change = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		stock_categories_list_cells(null, $name, $selected_id, $spec_opt, $submit_on_change);
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------------------
+	function fixed_asset_classes_list($name, $selected_id=null, $spec_opt=false, $submit_on_change=false)
+	{
+		$sql = "SELECT c.fa_class_id, CONCAT(c.fa_class_id,' - ',c.description) `desc`, CONCAT(p.fa_class_id,' - ',p.description) `class`, c.inactive FROM "
+			.TB_PREF."stock_fa_class c LEFT JOIN ".TB_PREF."stock_fa_class p ON c.parent_id=p.fa_class_id";
+	
+		return combo_input($name, $selected_id, $sql, 'c.fa_class_id', 'desc',
+			array('order'=>'c.fa_class_id',
+				'spec_option' => $spec_opt,
+				'spec_id' => '-1',
+				'select_submit'=> $submit_on_change,
+				'async' => true,
+				'search_box' => true,
+				'search' => array("c.fa_class_id"),
+				'search_submit' => false,
+				'spec_id' => '',
+				'size' => 3,
+				'max' => 3,
+				'category' => 'class',
+			));
+	}
+	
+	function fixed_asset_classes_list_row($label, $name, $selected_id=null, $spec_opt=false, $submit_on_change=false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		echo "<td>";
+		echo fixed_asset_classes_list($name, $selected_id, $spec_opt, $submit_on_change);
+		echo "</td></tr>\n";
+	}
+
+	//-----------------------------------------------------------------------------------------------
+	function gl_account_types_list($name, $selected_id = null, $all_option = false, $all = true)
+	{
+		$sql = "SELECT id, name FROM " . TB_PREF . "chart_types";
+
+		return combo_input($name, $selected_id, $sql, 'id', 'name', array(
+			'format' => '_format_account',
+			'order' => array(
+				'class_id',
+				'id',
+				'parent'
+			),
+			'spec_option' => $all_option,
+			'spec_id' => ALL_TEXT
+		));
+	}
+
+	function gl_account_types_list_cells($label, $name, $selected_id = null, $all_option = false, $all = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo gl_account_types_list($name, $selected_id, $all_option, $all);
+		echo "</td>\n";
+	}
+
+	function gl_account_types_list_row($label, $name, $selected_id = null, $all_option = false, $all = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		gl_account_types_list_cells(null, $name, $selected_id, $all_option, $all);
+		echo "</tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------------------
+	function gl_all_accounts_list($name, $selected_id = null, $skip_bank_accounts = false, $cells = false, $all_option = false, $submit_on_change = false, $all = false)
+	{
+		if ($skip_bank_accounts)
+			$sql = "SELECT chart.account_code, chart.account_name, type.name, chart.inactive, type.id
+			FROM (" . TB_PREF . "chart_master chart," . TB_PREF . "chart_types type) " . "LEFT JOIN " . TB_PREF . "bank_accounts acc " . "ON chart.account_code=acc.account_code
+				WHERE acc.account_code  IS NULL
+			AND chart.account_type=type.id";
+		else
+			$sql = "SELECT chart.account_code, chart.account_name, type.name, chart.inactive, type.id
+			FROM " . TB_PREF . "chart_master chart," . TB_PREF . "chart_types type
+			WHERE chart.account_type=type.id";
+
+		return combo_input($name, $selected_id, $sql, 'chart.account_code', 'chart.account_name', array(
+			'format' => '_format_account',
+			'spec_option' => $all_option === true ? _("Use Item Sales Accounts") : $all_option,
+			'spec_id' => '',
+			'type' => 2,
+			'order' => array(
+				'type.class_id',
+				'type.id',
+				'account_code'
+			),
+			'search_box' => $cells,
+			'search_submit' => false,
+			'size' => 12,
+			'max' => 10,
+			'cells' => true,
+			'select_submit' => $submit_on_change,
+			'async' => false,
+			'category' => 2,
+			'show_inactive' => $all
+		), "account" );
+	}
+
+	function _format_account($row)
+	{
+		return $row[0] . "&nbsp;&nbsp;&nbsp;&nbsp;" . $row[1];
+	}
+
+	function gl_all_accounts_list_cells($label, $name, $selected_id = null, $skip_bank_accounts = false, $cells = false, $all_option = false, $submit_on_change = false, $all = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo gl_all_accounts_list($name, $selected_id, $skip_bank_accounts, $cells, $all_option, $submit_on_change, $all);
+		echo "</td>\n";
+	}
+
+	function gl_all_accounts_list_row($label, $name, $selected_id = null, $skip_bank_accounts = false, $cells = false, $all_option = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		gl_all_accounts_list_cells(null, $name, $selected_id, $skip_bank_accounts, $cells, $all_option);
+		echo "</tr>\n";
+	}
+
+	function yesno_list($name, $selected_id = null, $name_yes = "", $name_no = "", $submit_on_change = false)
+	{
+		$items = array();
+		$items['0'] = strlen($name_no) ? $name_no : _("No");
+		$items['1'] = strlen($name_yes) ? $name_yes : _("Yes");
+
+		return array_selector($name, $selected_id, $items, array(
+			'select_submit' => $submit_on_change,
+			'async' => false
+		)); // FIX?
+	}
+
+	function yesno_list_cells($label, $name, $selected_id = null, $name_yes = "", $name_no = "", $submit_on_change = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo yesno_list($name, $selected_id, $name_yes, $name_no, $submit_on_change);
+		echo "</td>\n";
+	}
+
+	function yesno_list_row($label, $name, $selected_id = null, $name_yes = "", $name_no = "", $submit_on_change = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		yesno_list_cells(null, $name, $selected_id, $name_yes, $name_no, $submit_on_change);
+		echo "</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------------------
+	function languages_list($name, $selected_id = null, $all_option = false)
+	{
+		global $installed_languages;
+
+		$items = array();
+		if ($all_option)
+			$items[''] = $all_option;
+		foreach ($installed_languages as $lang)
+			$items[$lang['code']] = $lang['name'];
+		return array_selector($name, $selected_id, $items);
+	}
+
+	function languages_list_cells($label, $name, $selected_id = null, $all_option = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo languages_list($name, $selected_id, $all_option);
+		echo "</td>\n";
+	}
+
+	function languages_list_row($label, $name, $selected_id = null, $all_option = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		languages_list_cells(null, $name, $selected_id, $all_option);
+		echo "</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------------------
+	function bank_account_types_list($name, $selected_id = null)
+	{
+		global $bank_account_types;
+
+		return array_selector($name, $selected_id, $bank_account_types);
+	}
+
+	function bank_account_types_list_cells($label, $name, $selected_id = null)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo bank_account_types_list($name, $selected_id);
+		echo "</td>\n";
+	}
+
+	function bank_account_types_list_row($label, $name, $selected_id = null)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		bank_account_types_list_cells(null, $name, $selected_id);
+		echo "</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------------------
+	function payment_person_types_list($name, $selected_id = null, $submit_on_change = false)
+	{
+		global $payment_person_types;
+
+		$items = array();
+		foreach ($payment_person_types as $key => $type) {
+			if ($key != PT_WORKORDER)
+				$items[$key] = $type;
+		}
+		return array_selector($name, $selected_id, $items, array(
+			'select_submit' => $submit_on_change
+		));
+	}
+
+	function payment_person_types_list_cells($label, $name, $selected_id = null, $related = null)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo payment_person_types_list($name, $selected_id, $related);
+		echo "</td>\n";
+	}
+
+	function payment_person_types_list_row($label, $name, $selected_id = null, $related = null)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		payment_person_types_list_cells(null, $name, $selected_id, $related);
+		echo "</tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------------------
+	function wo_types_list($name, $selected_id = null)
+	{
+		global $wo_types_array;
+
+		return array_selector($name, $selected_id, $wo_types_array, array(
+			'select_submit' => true,
+			'async' => true
+		));
+	}
+
+	function wo_types_list_row($label, $name, $selected_id = null)
+	{
+		echo "<tr><td class='label'>$label</td><td>\n";
+		echo wo_types_list($name, $selected_id);
+		echo "</td></tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------------------
+	function dateformats_list_row($label, $name, $value = null)
+	{
+		global $SysPrefs;
+
+		echo "<tr><td class='label'>$label</td>\n<td>";
+		echo array_selector($name, $value, $SysPrefs->dateformats);
+		echo "</td></tr>\n";
+	}
+
+	function dateseps_list_row($label, $name, $value = null)
+	{
+		global $SysPrefs;
+
+		echo "<tr><td class='label'>$label</td>\n<td>";
+		echo array_selector($name, $value, $SysPrefs->dateseps);
+		echo "</td></tr>\n";
+	}
+
+	function thoseps_list_row($label, $name, $value = null)
+	{
+		global $SysPrefs;
+
+		echo "<tr><td class='label'>$label</td>\n<td>";
+		echo array_selector($name, $value, $SysPrefs->thoseps);
+		echo "</td></tr>\n";
+	}
+
+	function decseps_list_row($label, $name, $value = null)
+	{
+		global $SysPrefs;
+
+		echo "<tr><td class='label'>$label</td>\n<td>";
+		echo array_selector($name, $value, $SysPrefs->decseps);
+		echo "</td></tr>\n";
+	}
+
+	function themes_list_row($label, $name, $value = null)
+	{
+		global $path_to_root;
+
+		$path = $path_to_root . '/themes/';
+		$themes = array();
+		$themedir = opendir($path);
+		while (false !== ($fname = readdir($themedir))) {
+			if ($fname != '.' && $fname != '..' && $fname != 'CVS' && is_dir($path . $fname)) {
+				$themes[$fname] = $fname;
+			}
+		}
+		ksort($themes);
+
+		echo "<tr><td class='label'>$label</td>\n<td>";
+		echo array_selector($name, $value, $themes);
+		echo "</td></tr>\n";
+	}
+
+	function pagesizes_list_row($label, $name, $value = null)
+	{
+		global $SysPrefs;
+
+		$items = array();
+		foreach ($SysPrefs->pagesizes as $pz)
+			$items[$pz] = $pz;
+
+		echo "<tr><td class='label'>$label</td>\n<td>";
+		echo array_selector($name, $value, $items);
+		echo "</td></tr>\n";
+	}
+
+	function systypes_list($name, $value = null, $spec_opt = false, $submit_on_change = false, $exclude = array())
+	{
+		global $systypes_array;
+
+		// emove non-voidable transactions if needed
+		$systypes = array_diff_key($systypes_array, array_flip($exclude));
+		return array_selector($name, $value, $systypes, array(
+			'spec_option' => $spec_opt,
+			'spec_id' => ALL_NUMERIC,
+			'select_submit' => $submit_on_change,
+			'async' => false
+		));
+	}
+
+	function systypes_list_cells($label, $name, $value = null, $submit_on_change = false, $exclude = array())
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo systypes_list($name, $value, false, $submit_on_change, $exclude);
+		echo "</td>\n";
+	}
+
+	function systypes_list_row($label, $name, $value = null, $submit_on_change = false, $exclude = array())
+	{
+		echo "<tr><td class='label'>$label</td>";
+		systypes_list_cells(null, $name, $value, $submit_on_change, $exclude);
+		echo "</tr>\n";
+	}
+
+	function journal_types_list_cells($label, $name, $value = null, $submit_on_change = false)
+	{
+		global $systypes_array;
+
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+
+		$items = $systypes_array;
+
+		// exclude quotes, orders and dimensions
+		foreach (array(
+			ST_PURCHORDER,
+			ST_SALESORDER,
+			ST_DIMENSION,
+			ST_SALESQUOTE,
+			ST_LOCTRANSFER
+		) as $excl)
+			unset($items[$excl]);
+
+		echo array_selector($name, $value, $items, array(
+			'spec_option' => _("All"),
+			'spec_id' => - 1,
+			'select_submit' => $submit_on_change,
+			'async' => false
+		));
+		echo "</td>\n";
+	}
+
+	function cust_allocations_list_cells($label, $name, $selected = null)
+	{
+		if ($label != null)
+			label_cell($label);
+		echo "<td>\n";
+		$allocs = array(
+			ALL_TEXT => _("All Types"),
+			'1' => _("Sales Invoices"),
+			'2' => _("Overdue Invoices"),
+			'3' => _("Payments"),
+			'4' => _("Credit Notes"),
+			'5' => _("Delivery Notes")
+		);
+		echo array_selector($name, $selected, $allocs);
+		echo "</td>\n";
+	}
+
+	function supp_allocations_list_cell($name, $selected = null)
+	{
+		echo "<td>\n";
+		$allocs = array(
+			ALL_TEXT => _("All Types"),
+			'1' => _("Invoices"),
+			'2' => _("Overdue Invoices"),
+			'3' => _("Payments"),
+			'4' => _("Credit Notes"),
+			'5' => _("Overdue Credit Notes")
+		);
+		echo array_selector($name, $selected, $allocs);
+		echo "</td>\n";
+	}
+
+	function supp_transactions_list_cell($name, $selected = null)
+	{
+		echo "<td>\n";
+		$allocs = array(
+			ALL_TEXT => _("All Types"),
+			'6' => _("GRNs"),
+			'1' => _("Invoices"),
+			'2' => _("Overdue Invoices"),
+			'3' => _("Payments"),
+			'4' => _("Credit Notes"),
+			'5' => _("Overdue Credit Notes")
+		);
+
+		echo array_selector($name, $selected, $allocs);
+		echo "</td>\n";
+	}
+
+	function policy_list_cells($label, $name, $selected = null)
+	{
+		if ($label != null)
+			label_cell($label);
+		echo "<td>\n";
+		echo array_selector($name, $selected, array(
+			'' => _("Automatically put balance on back order"),
+			'CAN' => _("Cancel any quantites not delivered")
+		));
+		echo "</td>\n";
+	}
+
+	function policy_list_row($label, $name, $selected = null)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		policy_list_cells(null, $name, $selected);
+		echo "</tr>\n";
+	}
+
+	function credit_type_list_cells($label, $name, $selected = null, $submit_on_change = false)
+	{
+		if ($label != null)
+			label_cell($label);
+		echo "<td>\n";
+		echo array_selector($name, $selected, array(
+			'Return' => _("Items Returned to Inventory Location"),
+			'WriteOff' => _("Items Written Off")
+		), array(
+			'select_submit' => $submit_on_change
+		));
+		echo "</td>\n";
+	}
+
+	function credit_type_list_row($label, $name, $selected = null, $submit_on_change = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		credit_type_list_cells(null, $name, $selected, $submit_on_change);
+		echo "</tr>\n";
+	}
+
+	function number_list($name, $selected, $from, $to, $no_option = false)
+	{
+		$items = array();
+		for ($i = $from; $i <= $to; $i ++)
+			$items[$i] = "$i";
+
+		return array_selector($name, $selected, $items, array(
+			'spec_option' => $no_option,
+			'spec_id' => ALL_NUMERIC
+		));
+	}
+
+	function number_list_cells($label, $name, $selected, $from, $to, $no_option = false)
+	{
+		if ($label != null)
+			label_cell($label);
+		echo "<td>\n";
+		echo number_list($name, $selected, $from, $to, $no_option);
+		echo "</td>\n";
+	}
+
+	function number_list_row($label, $name, $selected, $from, $to, $no_option = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		echo number_list_cells(null, $name, $selected, $from, $to, $no_option);
+		echo "</tr>\n";
+	}
+
+	function print_profiles_list_row($label, $name, $selected_id = null, $spec_opt = false, $submit_on_change = true)
+	{
+		$sql = "SELECT profile FROM " . TB_PREF . "print_profiles" . " GROUP BY profile";
+		$result = db_query($sql, 'cannot get all profile names');
+		$profiles = array();
+		while ($myrow = db_fetch($result)) {
+			$profiles[$myrow['profile']] = $myrow['profile'];
+		}
+
+		echo "<tr>";
+		if ($label != null)
+			echo "<td class='label'>$label</td>\n";
+		echo "<td>";
+
+		echo array_selector($name, $selected_id, $profiles, array(
+			'select_submit' => $submit_on_change,
+			'spec_option' => $spec_opt,
+			'spec_id' => ''
+		));
+
+		echo "</td></tr>\n";
+	}
+
+	function printers_list($name, $selected_id = null, $spec_opt = false, $submit_on_change = false)
+	{
+		static $printers; // query only once for page display
+
+		if (! $printers) {
+			$sql = "SELECT id, name, description FROM " . TB_PREF . "printers";
+			$result = db_query($sql, 'cannot get all printers');
+			$printers = array();
+			while ($myrow = db_fetch($result)) {
+				$printers[$myrow['id']] = $myrow['name'] . '&nbsp;-&nbsp;' . $myrow['description'];
+			}
+		}
+		return array_selector($name, $selected_id, $printers, array(
+			'select_submit' => $submit_on_change,
+			'spec_option' => $spec_opt,
+			'spec_id' => ''
+		));
+	}
+
+	// ------------------------------------------------------------------------------------------------
+	function quick_entries_list($name, $selected_id = null, $type = null, $submit_on_change = false)
+	{
+		$where = false;
+		$sql = "SELECT id, description FROM " . TB_PREF . "quick_entries";
+		if ($type != null)
+			$sql .= " WHERE type=$type";
+
+		return combo_input($name, $selected_id, $sql, 'id', 'description', array(
+			'spec_id' => '',
+			'order' => 'description',
+			'select_submit' => $submit_on_change,
+			'async' => false
+		));
+	}
+
+	function quick_entries_list_cells($label, $name, $selected_id = null, $type, $submit_on_change = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo quick_entries_list($name, $selected_id, $type, $submit_on_change);
+		echo "</td>";
+	}
+
+	function quick_entries_list_row($label, $name, $selected_id = null, $type, $submit_on_change = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		quick_entries_list_cells(null, $name, $selected_id, $type, $submit_on_change);
+		echo "</tr>\n";
+	}
+
+	function quick_actions_list_row($label, $name, $selected_id = null, $submit_on_change = false)
+	{
+		global $quick_actions;
+
+		echo "<tr><td class='label'>$label</td><td>";
+		echo array_selector($name, $selected_id, $quick_actions, array(
+			'select_submit' => $submit_on_change
+		));
+		echo "</td></tr>\n";
+	}
+
+	function quick_entry_types_list_row($label, $name, $selected_id = null, $submit_on_change = false)
+	{
+		global $quick_entry_types;
+
+		echo "<tr><td class='label'>$label</td><td>";
+		echo array_selector($name, $selected_id, $quick_entry_types, array(
+			'select_submit' => $submit_on_change
+		));
+		echo "</td></tr>\n";
+	}
+
+	function record_status_list_row($label, $name)
+	{
+		return yesno_list_row($label, $name, null, _('Inactive'), _('Active'));
+	}
+
+	function class_types_list_row($label, $name, $selected_id = null, $submit_on_change = false)
+	{
+		global $class_types;
+
+		echo "<tr><td class='label'>$label</td><td>";
+		echo array_selector($name, $selected_id, $class_types, array(
+			'select_submit' => $submit_on_change
+		));
+		echo "</td></tr>\n";
+	}
+
+	// ------------------------------------------------------------------------------------------------
+	function security_roles_list($name, $selected_id = null, $new_item = false, $submit_on_change = false, $show_inactive = false)
+	{
+		$sql = "SELECT id, role, inactive FROM " . TB_PREF . "security_roles";
+
+		return combo_input($name, $selected_id, $sql, 'id', 'description', array(
+			'spec_option' => $new_item ? _("New role") : false,
+			'spec_id' => '',
+			'select_submit' => $submit_on_change,
+			'show_inactive' => $show_inactive
+		));
+	}
+
+	function security_roles_list_cells($label, $name, $selected_id = null, $new_item = false, $submit_on_change = false, $show_inactive = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+		echo security_roles_list($name, $selected_id, $new_item, $submit_on_change, $show_inactive);
+		echo "</td>\n";
+	}
+
+	function security_roles_list_row($label, $name, $selected_id = null, $new_item = false, $submit_on_change = false, $show_inactive = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		security_roles_list_cells(null, $name, $selected_id, $new_item, $submit_on_change, $show_inactive);
+		echo "</tr>\n";
+	}
+
+	function tab_list_row($label, $name, $selected_id = null)
+	{
+		global $installed_extensions;
+
+		$tabs = array();
+		foreach ($_SESSION['App']->applications as $app) {
+			$tabs[$app->id] = access_string($app->name, true);
+		}
+		echo "<tr>\n";
+		echo "<td class='label'>$label</td><td>\n";
+		echo array_selector($name, $selected_id, $tabs);
+		echo "</td></tr>\n";
+	}
+
+	// -----------------------------------------------------------------------------------------------
+	function tag_list($name, $height, $type, $multi = false, $all = false, $spec_opt = false)
+	{
+		// Get tags
+		global $path_to_root;
+		include_once ($path_to_root . "/admin/db/tags_db.inc");
+		$results = get_tags($type, $all);
+
+		while ($tag = db_fetch($results))
+			$tags[$tag['id']] = $tag['name'];
+
+		if (! isset($tags)) {
+			$tags[''] = $all ? _("No tags defined.") : _("No active tags defined.");
+			$spec_opt = false;
+		}
+		return array_selector($name, null, $tags, array(
+			'multi' => $multi,
+			'height' => $height,
+			'spec_option' => $spec_opt,
+			'spec_id' => - 1
+		));
+	}
+
+	function tag_list_cells($label, $name, $height, $type, $mult = false, $all = false, $spec_opt = false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>\n";
+		echo tag_list($name, $height, $type, $mult, $all, $spec_opt);
+		echo "</td>\n";
+	}
+
+	function tag_list_row($label, $name, $height, $type, $mult = false, $all = false, $spec_opt = false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		tag_list_cells(null, $name, $height, $type, $mult, $all, $spec_opt);
+		echo "</tr>\n";
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// List of sets of active extensions
+	//
+	function extset_list($name, $value = null, $submit_on_change = false)
+	{
+		global $db_connections;
+
+		$items = array();
+		foreach ($db_connections as $comp)
+			$items[] = sprintf(_("Activated for '%s'"), $comp['name']);
+		return array_selector($name, $value, $items, array(
+			'spec_option' => _("Available and/or installed"),
+			'spec_id' => - 1,
+			'select_submit' => $submit_on_change,
+			'async' => true
+		));
+	}
+
+	function crm_category_types_list($name, $selected_id = null, $filter = array(), $submit_on_change = true)
+	{
+		$sql = "SELECT id, name, type, inactive FROM " . TB_PREF . "crm_categories";
+
+		$multi = false;
+		$groups = false;
+		$where = array();
+		if (@$filter['class']) {
+			$where[] = 'type=' . db_escape($filter['class']);
+		} else
+			$groups = 'type';
+		if (@$filter['subclass'])
+			$where[] = 'action=' . db_escape($filter['subclass']);
+		if (@$filter['entity'])
+			$where[] = 'entity_id=' . db_escape($filter['entity']);
+		if (@$filter['multi']) { // contact category selector for person
+			$multi = true;
+		}
+
+		return combo_input($name, $selected_id, $sql, 'id', 'name', array(
+			'multi' => $multi,
+			'height' => $multi ? 5 : 1,
+			'category' => $groups,
+			'select_submit' => $submit_on_change,
+			'async' => true,
+			'where' => $where
+		));
+	}
+
+	function crm_category_types_list_row($label, $name, $selected_id = null, $filter = array(), $submit_on_change = true)
+	{
+		echo "<tr><td class='label'>$label</td><td>";
+		echo crm_category_types_list($name, $selected_id, $filter, $submit_on_change);
+		echo "</td></tr>\n";
+	}
+
+	function payment_type_list_row($label, $name, $selected_id = null, $submit_on_change = false)
+	{
+		global $pterm_types;
+
+		echo "<tr><td class='label'>$label</td><td>";
+		echo array_selector($name, $selected_id, $pterm_types, array(
+			'select_submit' => $submit_on_change
+		));
+		echo "</td></tr>\n";
+	}
+
+	function coa_list_row($label, $name, $value = null)
+	{
+		global $path_to_root, $installed_extensions;
+
+		$path = $path_to_root . '/sql/';
+		$coas = array();
+		$sqldir = opendir($path);
+		while (false !== ($fname = readdir($sqldir))) {
+			if (is_file($path . $fname) && substr($fname, - 4) == '.sql' && @($fname[2] == '_')) {
+				$ext = array_search_value($fname, $installed_extensions, 'sql');
+				if ($ext != null) {
+					$descr = $ext['name'];
+				} elseif ($fname == 'en_US-new.sql') { // two standard COAs
+					$descr = _("Standard new company American COA (4 digit)");
+				} elseif ($fname == 'en_US-demo.sql') {
+					$descr = _("Standard American COA (4 digit) with demo data");
+				} else
+					$descr = $fname;
+
+				$coas[$fname] = $descr;
+			}
+		}
+		ksort($coas);
+
+		echo "<tr><td class='label'>$label</td>\n<td>";
+		echo array_selector($name, $value, $coas);
+		echo "</td></tr>\n";
+	}
+
+	function payment_services($name)
+	{
+		global $payment_services;
+
+		$services = array_combine(array_keys($payment_services), array_keys($payment_services));
+
+		return array_selector($name, null, $services, array(
+			'spec_option' => _("No payment Link"),
+			'spec_id' => ''
+		));
+	}
+	
+	function tax_algorithm_list($name, $value=null, $submit_on_change = false)
+	{
+		global $tax_algorithms;
+	
+		return array_selector($name, $value, $tax_algorithms,
+			array(
+				'select_submit'=> $submit_on_change,
+				'async' => true,
+			)
+			);
+	}
+	
+	function tax_algorithm_list_cells($label, $name, $value=null, $submit_on_change=false)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+			echo "<td>";
+			echo tax_algorithm_list($name, $value, $submit_on_change);
+			echo "</td>\n";
+	}
+	
+	function tax_algorithm_list_row($label, $name, $value=null, $submit_on_change=false)
+	{
+		echo "<tr><td class='label'>$label</td>";
+		tax_algorithm_list_cells(null, $name, $value, $submit_on_change);
+		echo "</tr>\n";
+	}
+	
+	function refline_list($name, $type, $value=null, $spec_option=false)
+	{
+		$sql = "SELECT id, prefix, inactive FROM ".TB_PREF."reflines";
+	
+		$where = array();
+	
+		if (isset($type))
+			$where = array('`trans_type`='.db_escape($type));
+	
+			return combo_input($name, $value, $sql, 'id', 'prefix',
+				array(
+					'order'=>array('prefix'),
+					'spec_option' => $spec_option,
+					'spec_id' => '',
+					'type' => 2,
+					'where' => $where,
+					'select_submit' => true,
+				)
+				);
+	}
+	
+	function refline_list_row($label, $name, $type, $selected_id=null, $spec_option=false)
+	{
+		echo "<tr>";
+		if ($label != null)
+			echo "<td class='label'>$label</td>\n";
+			echo "<td>";
+	
+			echo refline_list($name, $type, $selected_id, $spec_option);
+			echo "</td></tr>\n";
+	}
+	
+	
+	//----------------------------------------------------------------------------------------------
+	
+	function subledger_list($name, $account, $selected_id=null)
+	{
+	
+		$type = is_subledger_account($account);
+		if (!$type)
+			return '';
+	
+		if($type > 0)
+			$sql = "SELECT DISTINCT d.debtor_no as id, debtor_ref as name
+					FROM "
+					.TB_PREF."debtors_master d,"
+					.TB_PREF."cust_branch c
+					WHERE d.debtor_no=c.debtor_no AND c.receivables_account=".db_escape($account);
+		else
+			$sql = "SELECT supplier_id as id, supp_ref as name
+					FROM "
+					.TB_PREF."suppliers s
+					WHERE s.payable_account=".db_escape($account);
+
+		$mode = get_company_pref('no_customer_list');
+
+		return combo_input($name, $selected_id, $sql, 'id', 'name',
+			array(
+				'type' => 1,
+				'size' => 20,
+				'async' => false,
+			));
+	}
+	
+	function subledger_list_cells($label, $name, $account, $selected_id=null)
+	{
+		if ($label != null)
+			echo "<td>$label</td>\n";
+			echo "<td nowrap>";
+			echo subledger_list($name, $account, $selected_id);
+			echo "</td>\n";
+	}
+	
+	function subledger_list_row($label, $name, $selected_id=null, $all_option = false,
+		$submit_on_change=false, $show_inactive=false, $editkey = false)
+	{
+		echo "<tr><td class='label'>$label</td><td nowrap>";
+		echo subledger_list($name, $account, $selected_id);
+		echo "</td>\n</tr>\n";
+	}
+	
+	function accounts_type_list_row($label, $name, $selected_id=null)
+	{
+		echo "<tr>";
+		if ($label != null)
+			echo "<td class='label'>$label</td>\n";
+		echo "<td>";
+		$sel = array(_("Numeric"), _("Alpha Numeric"), _("ALPHA NUMERIC"));
+		echo array_selector($name, $selected_id, $sel);
+		echo "</td></tr>\n";
+	}
+	
+	function users_list_cells($label, $name, $selected_id=null, $submit_on_change=false, $spec_opt=true)
+	{
+		$where = false;
+		$sql = " SELECT user_id, real_name FROM ".TB_PREF."users";
+	
+		if ($label != null)
+			echo "<td>$label</td>\n";
+		echo "<td>";
+	
+		echo combo_input($name, $selected_id, $sql, 'user_id', 'real_name',
+			array(
+				'spec_option' => $spec_opt===true ?_("All users") : $spec_opt,
+				'spec_id' => '',
+				'order' => 'real_name',
+				'select_submit'=> $submit_on_change,
+				'async' => false
+			) );
+		echo "</td>";
+	
+	}
+	
+	function collations_list_row($label, $name, $selected_id=null)
+	{
+		global $supported_collations;
+	
+		echo "<tr>";
+		if ($label != null)
+			echo "<td class='label'>$label</td>\n";
+		echo "<td>";
+	
+		echo array_selector($name, $selected_id, $supported_collations,
+			array('select_submit'=> false) );
+		echo "</td></tr>\n";
+	}
+	
+	
+}
+
+?>

--- a/includes/ui/db_pager_view.inc
+++ b/includes/ui/db_pager_view.inc
@@ -1,204 +1,37 @@
 <?php
 /**********************************************************************
     Copyright (C) FrontAccounting, LLC.
-	Released under the terms of the GNU General Public License, GPL, 
-	as published by the Free Software Foundation, either version 3 
+	Released under the terms of the GNU General Public License, GPL,
+	as published by the Free Software Foundation, either version 3
 	of the License, or (at your option) any later version.
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
     See the License here <http://www.gnu.org/licenses/gpl-3.0.html>.
 ***********************************************************************/
 //--------------------------------------------------------------------------------------------------
 function pager_link($link_text, $url, $icon=false)
 {
-	global $path_to_root;
-	
-	if (user_graphic_links() && $icon)
-		$link_text = set_icon($icon, $link_text);
-
-	$href = $path_to_root . $url;
-	return "<a href='$href'>" . $link_text . "</a>";
+	return ControlRenderer::get()->pager_link($link_text, $url, $icon);
 }
 
 function navi_button($name, $value, $enabled=true, $icon = false) {
-	global $path_to_root;
-  	return "<button ". ($enabled ? '':'disabled')
-  		." class=\"navibutton\" type=\"submit\""
-	    ." name=\"$name\"  id=\"$name\" value=\"$value\">"
-	  	.($icon ? "<img src='$path_to_root/themes/".user_theme()."/images/".$icon."'>":'')
-		."<span>$value</span></button>\n";
+	// NOTE: This function can be removed. It is private to the renderer implementation. CP 2014-11
+	return ControlRenderer::get()->pager_button($name, $value, $enabled, $icon);
 }
 
 function navi_button_cell($name, $value, $enabled=true, $align='left') {
-	label_cell(navi_button($name, $value, $enabled), "align='$align'");
+	// NOTE: This function can be removed. It is private to the renderer implementation. CP 2014-11
+	ControlRenderer::get()->pager_button_cell($name, $value, $enabled, $align);
 }
-
 
 //-----------------------------------------------------------------------------
 //
 //    Sql paged table view. Call this function inside form.
 //
 function display_db_pager(&$pager) {
-    global	$path_to_root;
-
-	$pager->select_records();
-
-	div_start("_{$pager->name}_span");
-    $headers = array();
-
-	foreach($pager->columns as $num_col=>$col) {
-		// record status control column is displayed only when control checkbox is on
-    	if (isset($col['head']) && ($col['type']!='inactive' || get_post('show_inactive'))) {
-			if (!isset($col['ord']))
-				$headers[] = $col['head'];
-			else {
-	  			$icon = (($col['ord'] == 'desc') ? 'sort_desc.gif' : 
-					($col['ord'] == 'asc' ? 'sort_asc.gif' : 'sort_none.gif'));
-				$headers[] = navi_button($pager->name.'_sort_'.$num_col, 
-					$col['head'], true, $icon);
-			}
- 		}
-	}
-    /* show a table of records returned by the sql */
-    start_table(TABLESTYLE, "width='$pager->width'");
-    table_header($headers);
-
-	if($pager->header_fun) {	// if set header handler
-		start_row("class='{$pager->header_class}'");
-		$fun = $pager->header_fun;
-		if (method_exists($pager, $fun)) { 
-			$h = $pager->$fun($pager);
-  		} elseif (function_exists($fun)) {
-			$h = $fun($pager);
-		}
-		
-		foreach($h as $c) {	 // draw header columns
-			$pars = isset($c[1]) ? $c[1] : '';
-			label_cell($c[0], $pars);
-		}
-		end_row();
-	}
-
-	$cc = 0; //row colour counter
-   	foreach($pager->data as $line_no => $row) {	
-
-		$marker = $pager->marker;
-	    if ($marker && $marker($row)) 
-        	start_row("class='$pager->marker_class'");
-	    else	
-			alt_table_row_color($cc);
-	    foreach ($pager->columns as $k=>$col) {
-		   $coltype = $col['type'];
-		   $cell = isset($col['name']) ? $row[$col['name']] : '';
-
-		   if (isset($col['fun'])) { // use data input function if defined
-		    $fun = $col['fun']; 
-		    if (method_exists($pager, $fun)) { 
-				$cell = $pager->$fun($row, $cell);
-  			} elseif (function_exists($fun)) {
-				$cell = $fun($row, $cell);
-			} else
-				$cell = '';
-		   }
-		   switch($coltype) { // format column
-		    case 'time':
-		  	  label_cell($cell, "width='40'"); break;
-		    case 'date':
-		  	  label_cell(sql2date($cell), "align='center' nowrap"); break;
-		    case 'dstamp':	// time stamp displayed as date
-		  	  label_cell(sql2date(substr($cell, 0, 10)), "align='center' nowrap"); break;
-		    case 'tstamp':	// time stamp - FIX user format
-		  	  label_cell(sql2date(substr($cell, 0, 10)).
-			  ' '. substr($cell, 10), "align='center'"); break;
-		    case 'percent':
-		  	  percent_cell($cell); break;
-		    case 'amount':
-			  if ($cell=='')
-			  	label_cell('');
-			  else
-		  	  	amount_cell($cell, false); break;
-		    case 'qty':
-			  if ($cell=='')
-			  	label_cell('');
-			  else
-		  	  	qty_cell($cell, false, isset($col['dec']) ? $col['dec'] : null); break;
-			case 'email':
-				email_cell($cell,isset( $col['align']) ? "align='" . $col['align'] . "'" : null);
-				break;
-		    case 'rate':
-				label_cell(number_format2($cell, user_exrate_dec()), "align=center"); break;
-			case 'inactive':
-				if(get_post('show_inactive'))
-					$pager->inactive_control_cell($row); break;
-		    default:
-			  if (isset( $col['align']))
-			  	  label_cell($cell, "align='" . $col['align'] . "'");
-			  else
-			  	  label_cell($cell);
-		    case 'skip':	// column not displayed
-	  	  }
-	  }
-	    end_row();
-	}
-	//end of while loop
-
-	if($pager->footer_fun) {	// if set footer handler
-		start_row("class='{$pager->footer_class}'");
-		$fun = $pager->footer_fun;
-		if (method_exists($pager, $fun)) { 
-			$h = $pager->$fun($pager);
-  		} elseif (function_exists($fun)) {
-			$h = $fun($pager);
-		}
-		
-		foreach($h as $c) {	 // draw footer columns
-			$pars = isset($c[1]) ? $c[1] : '';
-			label_cell($c[0], $pars);
-		}
-		end_row();
-	}
-
-	start_row("class='navibar'");
-	$colspan = count($pager->columns);
-		$inact = @$pager->inactive_ctrl==true 
-			? ' '.checkbox(null, 'show_inactive', null, true). _("Show also Inactive") : '';
-	 if($pager->rec_count) {
-		echo "<td colspan=$colspan class='navibar' style='border:none;padding:3px;'>";
-		echo "<div style='float:right;'>";
-		$but_pref = $pager->name.'_page_';
-	    start_table();
-		start_row();
-		if (@$pager->inactive_ctrl) 
-				submit('Update', _('Update'), true, '', null); // inactive update
-		echo navi_button_cell($but_pref.'first', _('First'), $pager->first_page, 'right');
-		echo navi_button_cell($but_pref.'prev', _('Prev'), $pager->prev_page,'right');
-		echo navi_button_cell($but_pref.'next', _('Next'), $pager->next_page,'right');
-		echo navi_button_cell($but_pref.'last', _('Last'), $pager->last_page, 'right');
-		end_row(); 
-		end_table();
-		echo "</div>";
-		$from = ($pager->curr_page-1)*$pager->page_len+1;
-		$to = $from + $pager->page_len - 1;
-		if ($to > $pager->rec_count)
-		  $to = $pager->rec_count;
-		$all = $pager->rec_count;
-		echo sprintf( _('Records %d-%d of %d'), $from, $to, $all);
-		echo $inact;
-		echo "</td>";
-	} else {
-	  	label_cell( _('No records') . $inact, "colspan=$colspan class='navibar'");
-	}
-
-	end_row();
-
-	end_table();
-
-   if (isset($pager->marker_txt))
-   		display_note($pager->marker_txt, 0, 1, "class='$pager->notice_class'");
-
-  div_end();
-  return true;
+	// Note that the return seems redundant CP 2014-11
+	return ControlRenderer::get()->pager($pager);
 }
 
-
+?>

--- a/includes/ui/ui_controls.inc
+++ b/includes/ui/ui_controls.inc
@@ -1,17 +1,20 @@
 <?php
 /**********************************************************************
     Copyright (C) FrontAccounting, LLC.
-	Released under the terms of the GNU General Public License, GPL, 
-	as published by the Free Software Foundation, either version 3 
+	Released under the terms of the GNU General Public License, GPL,
+	as published by the Free Software Foundation, either version 3
 	of the License, or (at your option) any later version.
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
     See the License here <http://www.gnu.org/licenses/gpl-3.0.html>.
 ***********************************************************************/
+
+include_once($path_to_root . "/includes/ui/ControlRenderer.inc");
+
 /*
 	Retrieve value of POST variable(s).
-	For $name passed as array $dflt is not used, 
+	For $name passed as array $dflt is not used,
 	default values can be passed as values with non-numeric keys instead.
 	If some field have user formatted numeric value, pass float default value to
 	convert automatically to POSIX.
@@ -32,387 +35,177 @@ function get_post($name, $dflt='')
 				((!isset($_POST[$name]) /*|| $_POST[$name] === ''*/) ? $dflt : $_POST[$name]);
 }
 //---------------------------------------------------------------------------------
-$form_nested = -1;
 
 function start_form($multi=false, $dummy=false, $action="", $name="")
 {
 	// $dummy - leaved for compatibility with 2.0 API
-	global $form_nested;
-
-	if (++$form_nested) return;
-
-	if ($name != "")
-		$name = "name='$name'";
-	if ($action == "")
-		$action = $_SERVER['PHP_SELF'];
-
-	if ($multi)
-		echo "<form enctype='multipart/form-data' method='post' action='$action' $name>\n";
-	else
-		echo "<form method='post' action='$action' $name>\n";
-
+	ControlRenderer::get()->start_form($multi, $dummy, $action, $name);
 }
 
-/*
-	Flush hidden fields buffer.
-*/
-function output_hidden()
-{
-	global $hidden_fields;
-
-	if (is_array($hidden_fields))
-		echo implode('', $hidden_fields);
-	$hidden_fields = array();
-}
 //---------------------------------------------------------------------------------
 
 function end_form($breaks=0)
 {
-	global $Ajax, $form_nested, $hidden_fields;
-
-	if ($form_nested-- > 0) return;
-
-	$_SESSION['csrf_token'] = hash('sha256', uniqid(mt_rand(), true));
-	if ($breaks)
-		br($breaks);
-	hidden('_focus');
-	hidden('_modified', get_post('_modified', 0));
-	hidden('_confirmed'); // helper for final form confirmation
-	hidden('_token', $_SESSION['csrf_token']);
-
-	output_hidden();
-	echo "</form>\n";
-	$Ajax->activate('_token');
-	$Ajax->activate('_confirmed');
+	ControlRenderer::get()->end_form($breaks);
 }
 
 function check_csrf_token()
 {
-	if ($_SESSION['csrf_token'] != @$_POST['_token'])
-	{
-		display_error(_("Request from outside of this page is forbidden."));
-		error_log(_("CSRF attack detected from: ").@$_SERVER['HTTP_HOST'].' ('.@$_SERVER['HTTP_REFERER'].')');
-		return false;
-	}
-	return true;
+	return ControlRenderer::get()->check_csrf_token();
 }
 
 function start_table($class=false, $extra="", $padding='2', $spacing='0')
 {
-	echo "<center><table";
-	if ($class == TABLESTYLE_NOBORDER)
-		echo " class='tablestyle_noborder'";
-	elseif ($class == TABLESTYLE2)
-		echo " class='tablestyle2'";
-	elseif ($class == TABLESTYLE)
-		echo " class='tablestyle'";
-	if ($extra != "")
-		echo " $extra";
-	echo " cellpadding='$padding' cellspacing='$spacing'>\n";
+	ControlRenderer::get()->start_table($class, $extra, $padding, $spacing);
 }
 
 function end_table($breaks=0)
 {
-	echo "</table></center>\n";
-	output_hidden();
-	if ($breaks)
-		br($breaks);
+	ControlRenderer::get()->end_table($breaks);
 }
 
 function start_outer_table($class=false, $extra="", $padding='2', $spacing='0', $br=false)
 {
-	if ($br)
-		br();
-	start_table($class, $extra, $padding, $spacing);
-	echo "<tr valign=top><td>\n"; // outer table
+	ControlRenderer::get()->start_outer_table($class, $extra, $padding, $spacing, $br);
 }
 
 function table_section($number=1, $width=false)
 {
-	if ($number > 1)
-	{
-		echo "</table>\n";
-		output_hidden();
-		$width = ($width ? "width='$width'" : "");
-		echo "</td><td style='border-left:1px solid #cccccc;' $width>\n"; // outer table
-	}
-	echo "<table class='tablestyle_inner'>\n";
-}	
+	ControlRenderer::get()->table_section($number, $width);
+}
 
 function end_outer_table($breaks=0, $close_table=true)
 {
-	if ($close_table)
-	{
-		echo "</table>\n";
-		output_hidden();
-	}
-	echo "</td></tr>\n";
-	end_table($breaks);
+	ControlRenderer::get()->end_outer_table($breaks, $close_table);
 }
 //
 //  outer table spacer
 //
 function vertical_space($params='')
 {
-	echo "</td></tr><tr><td valign=center $params>";
+	ControlRenderer::get()->vertical_space();
 }
 
-function meta_forward($forward_to, $params="", $timeout=0)
+function meta_forward($forward_to, $params="")
 {
-    global $Ajax;
-	echo "<meta http-equiv='Refresh' content='".$timeout."; url=$forward_to?$params'>\n";
-	echo "<center><br>" . _("You should automatically be forwarded.");
-	echo " " . _("If this does not happen") . " " . "<a href='$forward_to?$params'>" . _("click here") . "</a> " . _("to continue") . ".<br><br></center>\n";
-	if ($params !='') $params = '?'.$params;
-	$Ajax->redirect($forward_to.$params);
-	exit;
+	ControlRenderer::get()->meta_forward($forward_to, $params);
 }
 
 //-----------------------------------------------------------------------------------
 // Find and replace hotkey marker.
-// if $clean == true marker is removed and clean label is returned 
-// (for use in wiki help system), otherwise result is array of label 
+// if $clean == true marker is removed and clean label is returned
+// (for use in wiki help system), otherwise result is array of label
 // with underlined hotkey letter and access property string.
 //
 function access_string($label, $clean=false)
 {
-	$access = '';
-	$slices = array();
-
-	if (preg_match('/(.*)&([a-zA-Z0-9])(.*)/', $label, $slices))	
-	{
-		$label = $clean ? $slices[1].$slices[2].$slices[3] :
-			$slices[1].'<u>'.$slices[2].'</u>'.$slices[3];
-		$access = " accesskey='".strtoupper($slices[2])."'";
-	}
-	
-	$label = str_replace( '&&', '&', $label);
-
-	return $clean ? $label : array($label, $access);
+	return ControlRenderer::get()->access_string($label, $clean);
 }
 
 function hyperlink_back($center=true, $no_menu=true, $type_no=0, $trans_no=0, $final=false)
 {
-	global $path_to_root;
-
-	if ($center)
-		echo "<center>";
-	$id = 0;	
-	if ($no_menu && $trans_no != 0)
-	{
-		include_once($path_to_root."/admin/db/attachments_db.inc");
-		$id = has_attachment($type_no, $trans_no);
-		$attach = get_attachment_string($type_no, $trans_no);
-    	echo $attach;
-	}
-	$width = ($id != 0 ? "30%" : "20%");	
-	start_table(false, "width='$width'");
-	start_row();
-	if ($no_menu)
-	{
-		echo "<td align=center><a href='javascript:window.print();'>"._("Print")."</a></td>\n";
-	}	
-	echo "<td align=center><a href='javascript:goBack(".($final ? '-2' : '').");'>".($no_menu ? _("Close") : _("Back"))."</a></td>\n";
-	end_row();
-	end_table();
-	if ($center)
-		echo "</center>";
-	echo "<br>";
+	ControlRenderer::get()->hyperlink_back($center, $no_menu, $type_no, $trans_no, $final);
 }
 
 function hyperlink_no_params($target, $label, $center=true)
 {
-	$id = default_focus();
-	$pars = access_string($label);
-	if ($target == '')
-		$target = $_SERVER['PHP_SELF'];
-	if ($center)
-		echo "<br><center>";
-	echo "<a href='$target' id='$id' $pars[1]>$pars[0]</a>\n";
-	if ($center)
-		echo "</center>";
+	ControlRenderer::get()->hyperlink_no_params($target, $label, $center);
 }
 
 function hyperlink_no_params_td($target, $label)
 {
-	echo "<td>";
-	hyperlink_no_params($target, $label);
-	echo "</td>\n";
+	ControlRenderer::get()->hyperlink_no_params_td($target, $label);
 }
 
 function viewer_link($label, $url='', $class='', $id='',  $icon=null)
 {
-	global $path_to_root;
-	
-	if ($class != '')
-		$class = " class='$class'";
-
-	if ($id != '')
-		$class = " id='$id'";
-
-	if ($url != "")
-	{
-		$pars = access_string($label);
-		if (user_graphic_links() && $icon)
-			$pars[0] = set_icon($icon, $pars[0]);
--		$preview_str = "<a target='_blank' $class $id href='$path_to_root/$url' onclick=\"javascript:openWindow(this.href,this.target); return false;\"$pars[1]>$pars[0]</a>";
-	}
-	else
-		$preview_str = $label;
- return $preview_str;
+	return ControlRenderer::get()->viewer_link($label, $url, $class, $id, $icon);
 }
 
 function menu_link($url, $label, $id=null)
 {
-	global $path_to_root;
-
-	$id = default_focus($id);
-	$pars = access_string($label);
-
-	if ($url[0] != '/')
-		$url = '/'.$url;
-	$url = $path_to_root.$url;
-
-	return "<a href='$url' class='menu_option' id='$id' $pars[1]>$pars[0]</a>";
+	return ControlRenderer::get()->menu_link($url, $label, $id);
 }
 
 function submenu_option($title, $url, $id=null)
 {
-	display_note( menu_link($url, $title, $id), 0, 1);
+	ControlRenderer::get()->submenu_option($title, $url, $id);
 }
 
 function submenu_view($title, $type, $number, $id=null)
 {
-	display_note(get_trans_view_str($type, $number, $title, false, 'viewlink', $id), 0, 1);
+	ControlRenderer::get()->submenu_view($title, $type, $number, $id);
 }
 
 function submenu_print($title, $type, $number, $id=null, $email=0, $extra=0)
 {
-	display_note(print_document_link($number, $title, true, $type, false, 'printlink', $id, $email, $extra), 0, 1);
+	ControlRenderer::get()->submenu_print($title, $type, $number, $id, $email, $extra);
 }
 //-----------------------------------------------------------------------------------
 
 function hyperlink_params($target, $label, $params, $center=true)
 {
-	$id = default_focus();
-	
-	$pars = access_string($label);
-	if ($target == '')
-		$target = $_SERVER['PHP_SELF'];
-	if ($center)
-		echo "<br><center>";
-	echo "<a id='$id' href='$target?$params'$pars[1]>$pars[0]</a>\n";
-	if ($center)
-		echo "</center>";
+	ControlRenderer::get()->hyperlink_params($target, $label, $params, $center);
 }
 
 function hyperlink_params_td($target, $label, $params)
 {
-	echo "<td>";
-	hyperlink_params($target, $label, $params, false);
-	echo "</td>\n";
+	ControlRenderer::get()->hyperlink_params_td($target, $label, $params);
 }
 
 //-----------------------------------------------------------------------------------
 
 function hyperlink_params_separate($target, $label, $params, $center=false)
 {
-	$id = default_focus();
-
-	$pars = access_string($label);
-	if ($center)
-		echo "<br><center>";
-	echo "<a target='_blank' id='$id' href='$target?$params' $pars[1]>$pars[0]</a>\n";
-	if ($center)
-		echo "</center>";
+	ControlRenderer::get()->hyperlink_params_separate($target, $label, $params, $center);
 }
 
 function hyperlink_params_separate_td($target, $label, $params)
 {
-	echo "<td>";
-	hyperlink_params_separate($target, $label, $params);
-	echo "</td>\n";
+	ControlRenderer::get()->hyperlink_params_td($target, $label, $params);
 }
 
 //--------------------------------------------------------------------------------------------------
 
 function alt_table_row_color(&$k, $extra_class=null)
 {
-	$classes = $extra_class ? array($extra_class) : array();
-	if ($k == 1)
-	{
-		array_push($classes, 'oddrow');
-		$k = 0;
-	}
-	else
-	{
-		array_push($classes, 'evenrow');
-		$k++;
-	}
-	echo "<tr class='".implode(' ', $classes)."'>\n";
+	ControlRenderer::get()->alt_table_row_color($k, $extra_class);
 }
 
 function table_section_title($msg, $colspan=2)
 {
-	echo "<tr><td colspan=$colspan class='tableheader'>$msg</td></tr>\n";
+	ControlRenderer::get()->table_section_title($msg, $colspan);
 }
 
 function table_header($labels, $params='')
 {
-	start_row();
-	foreach ($labels as $label)
-		labelheader_cell($label, $params);
-	end_row();
+	ControlRenderer::get()->table_header($labels, $params);
 }
 //-----------------------------------------------------------------------------------
 
 function start_row($param="")
 {
-	if ($param != "")
-		echo "<tr $param>\n";
-	else
-		echo "<tr>\n";
+	ControlRenderer::get()->start_row($param);
 }
 
 function end_row()
 {
-	echo "</tr>\n";
+	ControlRenderer::get()->end_row();
 }
 
 function br($num=1)
 {
-	for ($i = 0; $i < $num; $i++)
-		echo "<br>";
+	ControlRenderer::get()->br($num);
 }
-
-$ajax_divs = array();
 
 function div_start($id='', $trigger=null, $non_ajax=false)
 {
-    global $ajax_divs;
-
-	if ($non_ajax) { // div for non-ajax elements
-   		array_push($ajax_divs, array($id, null));
-   		echo "<div style='display:none' class='js_only' ".($id !='' ? "id='$id'" : '').">";
-	} else { // ajax ready div
-   		array_push($ajax_divs, array($id, $trigger===null ? $id : $trigger));
-   		echo "<div ". ($id !='' ? "id='$id'" : '').">";
-   		ob_start();
-	}
+	ControlRenderer::get()->div_start($id, $trigger, $non_ajax);
 }
 
 function div_end()
 {
-    global $ajax_divs, $Ajax;
-
-	output_hidden();
-    if (count($ajax_divs))
-    {
-		$div = array_pop($ajax_divs);
-		if ($div[1] !== null)
-			$Ajax->addUpdate($div[1], $div[0], ob_get_flush());
-    }
-	echo "</div>";
+	ControlRenderer::get()->div_end();
 }
 
 //-----------------------------------------------------------------------------
@@ -424,76 +217,38 @@ function div_end()
 // $tabs - array of tabs; string: tab title or array(tab_title, enabled_status)
 
 function tabbed_content_start($name, $tabs, $dft='') {
-    global $Ajax;
-
-    $selname = '_'.$name.'_sel';
-	$div = '_'.$name.'_div';
-
-	$sel = find_submit($name.'_', false);
-	if($sel==null)
-		$sel = get_post($selname, (string)($dft==='' ? key($tabs) : $dft));
-
-	if ($sel!==@$_POST[$selname])
-		$Ajax->activate($name);
-
-	$_POST[$selname] = $sel;
-
-	div_start($name);
-	$str = "<ul class='ajaxtabs' rel='$div'>\n";
-	foreach($tabs as $tab_no => $tab) {
-		
-		$acc = access_string(is_array($tab) ? $tab[0] : $tab);
-		$disabled = (is_array($tab) && !$tab[1])  ? 'disabled ' : '';
-		$str .= ( "<li>"
-			."<button type='submit' name='{$name}_".$tab_no
-			."' class='".((string)$tab_no===$sel ? 'current':'ajaxbutton')."' $acc[1] $disabled>"
-			."<span>$acc[0]</span>"
-			."</button>\n"
-			."</li>\n" );
-	}
-
-	$str .= "</ul>\n";
-	$str .= "<div class='spaceBox'></div>\n";
-	$str .= "<input type='hidden' name='$selname' value='$sel'>\n";
-	$str .= "<div class='contentBox' id='$div'>\n";
-	echo $str;
+	ControlRenderer::get()->tabbed_content_start($name, $tabs, $dft);
 }
 
 function tabbed_content_end() {
-	output_hidden();
-	echo "</div>"; // content box (don't change to div_end() unless div_start() is used above)
-	div_end(); // tabs widget
+	ControlRenderer::get()->tabbed_content_end();
 }
 
 function tab_changed($name)
 {
-	$to = find_submit("{$name}_", false);
-	if (!$to) return null;
-
-	return array('from' => $from = get_post("_{$name}_sel"),
-		'to' => $to);
+	return ControlRenderer::get()->tab_changed($name);
 }
+
 /*
-	Check whether tab has been just switched on
-*/
+ Check whether tab has been just switched on
+ */
 function tab_opened($name, $tab)
 {
-	return (get_post('_'.$name.'_sel') != $tab) && (find_submit($name.'_', false) == $tab);
+	return ControlRenderer::get()->tab_opened($name, $tab);
 }
 /*
-	Check whether tab has been just switched off
-*/
+ Check whether tab has been just switched off
+ */
 function tab_closed($name, $tab)
 {
-	return (get_post('_'.$name.'_sel') == $tab) && (find_submit($name.'_', false) != $tab);
+	return ControlRenderer::get()->tab_closed($name, $tab);
 }
 /*
-	Check whether tab is visible on current page
-*/
+ Check whether tab is visible on current page
+ */
 function tab_visible($name, $tab)
 {
-	$new = find_submit($name.'_', false);
-	return (get_post('_'.$name.'_sel') == $tab && !$new) || $new==$tab;
+	return ControlRenderer::get()->tab_visible($name, $tab);
 }
 
 /* Table editor interfaces. Key is editor type
@@ -502,13 +257,13 @@ function tab_visible($name, $tab)
 	2 => context help
 */
 $popup_editors = array(
-	'customer' => array('/sales/manage/customers.php?debtor_no=', 
+	'customer' => array('/sales/manage/customers.php?debtor_no=',
 		113,	_("Customers"), 900, 500),
-	'branch' => array('/sales/manage/customer_branches.php?SelectedBranch=', 
+	'branch' => array('/sales/manage/customer_branches.php?SelectedBranch=',
 		114, _("Branches"), 900, 700),
-	'supplier' => array('/purchasing/manage/suppliers.php?supplier_id=', 
+	'supplier' => array('/purchasing/manage/suppliers.php?supplier_id=',
 		113, _("Suppliers"), 900, 700),
-	'item' => array('/inventory/manage/items.php?stock_id=', 
+	'item' => array('/inventory/manage/items.php?stock_id=',
 		115, _("Items"), 800, 600),
 	'fa_item' => array('/inventory/manage/items.php?FixedAsset=1&stock_id=', 
 		115, _("Items"), 800, 600)
@@ -526,9 +281,9 @@ function set_editor($type, $input, $caller=true)
 
 	$key = $caller===true ? $popup_editors[$type][1] : $caller;
 
-	$Editors[$key] = array( $path_to_root . $popup_editors[$type][0], $input, 
+	$Editors[$key] = array( $path_to_root . $popup_editors[$type][0], $input,
 		$popup_editors[$type][3], $popup_editors[$type][4]);
-	
+
 	$help = 'F' . ($key - 111) . ' - ';
 	$help .= $popup_editors[$type][2];
 	$Pagehelp[] = $help;
@@ -539,21 +294,21 @@ function set_editor($type, $input, $caller=true)
 /*
 	External page call with saving current context.
 	$call - url of external page
-	$ctx - optional. name of SESSION context object or array of names of POST 
+	$ctx - optional. name of SESSION context object or array of names of POST
 		variables saved on call
 */
 function context_call($call, $ctx='')
 {
-	if (is_array($ctx)) 
+	if (is_array($ctx))
 	{
 		foreach($ctx as $postname)
 		{
 		 	$context[$postname] = get_post($postname);
 		}
-	} else 
+	} else
 		$context = isset($_SESSION[$ctx]) ? $_SESSION[$ctx] : null;
 
-	array_unshift($_SESSION['Context'], array('name' => $ctx, 
+	array_unshift($_SESSION['Context'], array('name' => $ctx,
 		'ctx' => $context,
 		'caller' => $_SERVER['PHP_SELF'],
 		'ret' => array()));
@@ -570,7 +325,7 @@ function context_restore()
 			$ctx = array_shift($_SESSION['Context']);
 			if ($ctx) {
 				if (is_array($ctx['ctx'])) {
-					foreach($ctx['ctx'] as $name => $val) 
+					foreach($ctx['ctx'] as $name => $val)
 					{
 						$_POST[$name] = $val;
 					}
@@ -647,10 +402,11 @@ function confirm_dialog($submit, $msg) {
 	} else
 		return get_post('DialogConfirm', 0);
 }
+
 /*
-	Confirm dialog to be used optionally in final form checking routine.
-	Displays warning conditionally unless it was displayed
-*/
+ Confirm dialog to be used optionally in final form checking routine.
+ Displays warning conditionally unless it was displayed
+ */
 function display_confirmation($msg)
 {
 	global $Ajax;
@@ -663,6 +419,7 @@ function display_confirmation($msg)
 	} else
 		return true;
 }
+
 /*
 	Block menu/shortcut links during transaction procesing.
 */
@@ -691,3 +448,5 @@ function page_modified($status = true)
 	} else
 		add_js_source($js);
 }
+
+?>

--- a/includes/ui/ui_input.inc
+++ b/includes/ui/ui_input.inc
@@ -1,14 +1,17 @@
 <?php
 /**********************************************************************
     Copyright (C) FrontAccounting, LLC.
-	Released under the terms of the GNU General Public License, GPL, 
-	as published by the Free Software Foundation, either version 3 
+	Released under the terms of the GNU General Public License, GPL,
+	as published by the Free Software Foundation, either version 3
 	of the License, or (at your option) any later version.
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
     See the License here <http://www.gnu.org/licenses/gpl-3.0.html>.
 ***********************************************************************/
+
+include_once($path_to_root . "/includes/ui/InputRenderer.inc");
+
 //
 // Sets local POST value and adds Value to ajax posting if needed
 //
@@ -26,24 +29,16 @@
 //
 function find_submit($prefix, $numeric=true)
 {
-
-    foreach($_POST as $postkey=>$postval )
-    {
-		if (strpos($postkey, $prefix) === 0)
-		{
-			$id = substr($postkey, strlen($prefix));
-			return $numeric ? (int)$id : $id;
-		}
-    }
-    return $numeric ? -1 : null;
+	return InputRenderer::get()->find_submit($prefix, $numeric);
 }
+
 /*
-	Helper function.
-	Returns true if input $name with $submit_on_change option set is subject to update.
-*/
+ Helper function.
+ Returns true if input $name with $submit_on_change option set is subject to update.
+ */
 function input_changed($name)
 {
-	return isset($_POST['_'.$name.'_changed']);
+	return InputRenderer::get()->input_changed($name);
 }
 
 //------------------------------------------------------------------------------
@@ -52,32 +47,7 @@ function input_changed($name)
 //
 function simple_page_mode($numeric_id = true)
 {
-	global $Ajax, $Mode, $selected_id;
-
-	$default = $numeric_id ? -1 : '';
-	$selected_id = get_post('selected_id', $default);
-	foreach (array('ADD_ITEM', 'UPDATE_ITEM', 'RESET', 'CLONE') as $m) {
-		if (isset($_POST[$m])) {
-			$Ajax->activate('_page_body');
-			if ($m == 'RESET'  || $m == 'CLONE') 
-				$selected_id = $default;
-			unset($_POST['_focus']);
-			$Mode = $m; return;
-		}
-	}
-	foreach (array('Edit', 'Delete') as $m) {
-		foreach ($_POST as $p => $pvar) {
-			if (strpos($p, $m) === 0) {
-//				$selected_id = strtr(substr($p, strlen($m)), array('%2E'=>'.'));
-				unset($_POST['_focus']); // focus on first form entry
-				$selected_id = quoted_printable_decode(substr($p, strlen($m)));
-				$Ajax->activate('_page_body');
-				$Mode = $m;
-				return;
-			}
-		}
-	}
-	$Mode = '';
+	InputRenderer::get()->simple_page_mode($numeric_id);
 }
 
 //------------------------------------------------------------------------------
@@ -86,33 +56,14 @@ function simple_page_mode($numeric_id = true)
 //
 function input_num($postname=null, $dflt=0)
 {
-	if (!isset($_POST[$postname]) || $_POST[$postname] == "")
-	  	return $dflt;
-
-    return user_numeric($_POST[$postname]);
+	return InputRenderer::get()->input_num($postname, $dflt);
 }
 
 //---------------------------------------------------------------------------------
-//
-//	Thanks to hidden fields buffering hidden() helper can be used in arbitrary places and 
-//  proper html structure is still preserved. Buffered hidden fields are output on the nearest 
-//  table or form closing tag (see output_hidden()).
-//
-$hidden_fields = array();
 
 function hidden($name, $value=null, $echo=true)
 {
-  	global $Ajax, $hidden_fields;
-	
-	if ($value === null) 
-		$value = get_post($name);
-	
-  	$ret = "<input type=\"hidden\" name=\"$name\" value=\"$value\">";
-	$Ajax->addUpdate($name, $name, $value);
-	if ($echo)
-			$hidden_fields[] = $ret;
-	else
-		return $ret;
+	return InputRenderer::get()->hidden($name, $value, $echo);
 }
 /*
 	Universal submit form button.
@@ -128,703 +79,299 @@ function hidden($name, $value=null, $echo=true)
 		'cancel'  - cancel form entry on Escape press; dflt ICON_CANCEL
 		'process' - displays progress bar during call; optional icon
 		'nonajax' - ditto, non-ajax submit
-
-	$atype can contain also multiply type selectors separated by space, 
+	$atype can contain also multiply type selectors separated by space,
 	however make sense only combination of 'process' and one of defualt/selector/cancel
 */
 function submit($name, $value, $echo=true, $title=false, $atype=false, $icon=false)
 {
-	global $path_to_root;
-
-	$aspect='';
-	if ($atype === null) {
-		$aspect = fallback_mode() ? " aspect='fallback'" : " style='display:none;'";
-
-	} elseif (!is_bool($atype)) { // necessary: switch uses '=='
-
-		$aspect = " aspect='$atype' ";
-		$types = explode(' ', $atype);
-
-		foreach ($types as $type) {
-			switch($type) {
-				case 'selector':
-					$aspect = " aspect='selector' rel = '$value'"; 
-					$value = _("Select");
-					if ($icon===false) $icon=ICON_SUBMIT; break;
-
-				case 'default':
-					if ($icon===false) $icon=ICON_SUBMIT; break;
-
-				case 'cancel':
-					if ($icon===false) $icon=ICON_ESCAPE; break;
-
-				case 'nonajax':
-					$atype = false;
-			}
-		}
-	}
-	$submit_str = "<button class=\""
-	    .($atype ? 'ajaxsubmit' : 'inputsubmit')
-		."\" type=\"submit\""
-		.$aspect
-	    ." name=\"$name\"  id=\"$name\" value=\"$value\""
-	    .($title ? " title='$title'" : '')
-	    .">"
-		.($icon ? "<img src='$path_to_root/themes/".user_theme()."/images/$icon' height='12' alt=''>" : '')
-		."<span>$value</span>"
-		."</button>\n";
-	if ($echo)
-		echo $submit_str;
-	else
-		return $submit_str;
+	return InputRenderer::get()->submit($name, $value, $echo, $title, $atype, $icon);
 }
 
 function submit_center($name, $value, $echo=true, $title=false, $async=false, $icon=false)
 {
-	if ($echo) echo "<center>";
-	submit($name, $value, $echo, $title, $async, $icon);
-	if ($echo) echo "</center>";
+	InputRenderer::get()->submit_center($name, $value, $echo, $title, $async, $icon);
 }
 
 function submit_center_first($name, $value, $title=false, $async=false, $icon=false)
 {
-	echo "<center>";
-	submit($name, $value, true, $title, $async, $icon);
-	echo "&nbsp;";
+	InputRenderer::get()->submit_center_first($name, $value, $title, $async, $icon);
 }
 
 function submit_center_last($name, $value, $title=false, $async=false, $icon=false)
 {
-	echo "&nbsp;";
-	submit($name, $value, true, $title, $async, $icon);
-	echo "</center>";
+	InputRenderer::get()->submit_center_last($name, $value, $title, $async, $icon);
 }
 /*
 	For following controls:
-	'both' - use both Ctrl-Enter and Escape hotkeys 
-	'upgrade' - use Ctrl-Enter with progress ajax indicator and Escape hotkeys. Nonajax request for OK option is performed.
+	'both' - use both Ctrl-Enter and Escape hotkeys
 	'cancel' - apply to 'RESET' button
 */
 function submit_add_or_update($add=true, $title=false, $async=false, $clone=false)
 {
-	$cancel = $async;
-
-	if ($async === 'both') {
-		$async = 'default'; $cancel = 'cancel';
-	}
-	elseif ($async === 'upgrade') {
-		$async = 'default nonajax process'; $cancel = 'cancel';
-	}
-	elseif ($async === 'default')
-		$cancel = true;
-	elseif ($async === 'cancel')
-		$async = true;
-	
-	if ($add)
-		submit('ADD_ITEM', _("Add new"), true, $title, $async);
-	else {
-		submit('UPDATE_ITEM', _("Update"), true, _('Submit changes'), $async);
-		if ($clone) submit('CLONE', _("Clone"), true, 
-			_('Edit new record with current data'), $async);
-		submit('RESET', _("Cancel"), true, _('Cancel edition'), $cancel);
-	}
+	InputRenderer::get()->submit_add_or_update($add, $title, $async, $clone);
 }
 
 function submit_add_or_update_center($add=true, $title=false, $async=false, $clone=false)
 {
-	echo "<center>";
-	submit_add_or_update($add, $title, $async, $clone);
-	echo "</center>";
+	InputRenderer::get()->submit_add_or_update_center($add, $title, $async, $clone);
 }
 
 function submit_add_or_update_row($add=true, $right=true, $extra="", $title=false, $async=false, $clone = false)
 {
-	echo "<tr>";
-	if ($right)
-		echo "<td>&nbsp;</td>\n";
-	echo "<td $extra>";
-	submit_add_or_update($add, $title, $async, $clone);
-	echo "</td></tr>\n";
+	InputRenderer::get()->submit_add_or_update_row($add, $right, $extra, $title, $async, $clone);
 }
 
 function submit_cells($name, $value, $extra="", $title=false, $async=false)
 {
-	echo "<td $extra>";
-	submit($name, $value, true, $title, $async);
-	echo "</td>\n";
+	InputRenderer::get()->submit_cells($name, $value, $extra, $title, $async);
 }
 
 function submit_row($name, $value, $right=true, $extra="", $title=false, $async=false)
 {
-	echo "<tr>";
-	if ($right)
-		echo "<td>&nbsp;</td>\n";
-	submit_cells($name, $value, $extra, $title, $async);
-	echo "</tr>\n";
+	InputRenderer::get()->submit_row($name, $value, $right, $extra, $title, $async);
 }
 
 function submit_return($name, $value, $title=false)
 {
-	if (@$_REQUEST['popup']) {
-		submit($name, $value, true, $title, 'selector');
-	}
+	InputRenderer::get()->submit_return($name, $value, $title);
 }
 
-function submit_js_confirm($name, $msg, $set = true) {
-	global $Ajax;
-	$js = "_validate.$name=".($set ? "function(){ return confirm('"
-				. strtr($msg, array("\n"=>'\\n')) . "');};"
-				: 'null;');
-	if (in_ajax()) {
-		$Ajax->addScript(true, $js);
-	} else
-		add_js_source($js);
+function submit_js_confirm($name, $msg, $set = true)
+{
+	InputRenderer::get()->submit_js_confirm($name, $msg, $set);
 }
 //-----------------------------------------------------------------------------------
 
 function set_icon($icon, $title=false)
 {
-	global $path_to_root;
-	if (basename($icon) === $icon) // standard icons does not contain path separator
-		$icon = "$path_to_root/themes/".user_theme()."/images/$icon";
-	return "<img src='$icon' style='vertical-align:middle;width:12px;height:12px;border:0;'".($title ? " title='$title'" : "")." >\n";	
+	return InputRenderer::get()->set_icon($icon, $title);
 }
 
 function button($name, $value, $title=false, $icon=false,  $aspect='')
 {
-	// php silently changes dots,spaces,'[' and characters 128-159
-	// to underscore in POST names, to maintain compatibility with register_globals
-	$rel = '';
-	if ($aspect == 'selector') {
-		$rel = " rel='$value'";
-		$value = _("Select");
-	}
-	if (user_graphic_links() && $icon)
-	{
-		if ($value == _("Delete")) // Helper during implementation
-			$icon = ICON_DELETE;
-		return "<button type='submit' class='editbutton' name='"
-			.htmlentities(strtr($name, array('.'=>'=2E', '='=>'=3D',// ' '=>'=20','['=>'=5B'
-			)))
-			."' value='1'" . ($title ? " title='$title'":" title='$value'")
-			. ($aspect ? " aspect='$aspect'" : '')
-			. $rel
-			." >".set_icon($icon)."</button>\n";
-	}
-	else
-		return "<input type='submit' class='editbutton' name='"
-			.htmlentities(strtr($name, array('.'=>'=2E', '='=>'=3D',// ' '=>'=20','['=>'=5B'
-			)))
-			."' value='$value'"
-			.($title ? " title='$title'":'')
-			. ($aspect ? " aspect='$aspect'" : '')
-			. $rel
-			." >\n";
+	return InputRenderer::get()->button($name, $value, $title, $icon, $aspect);
 }
 
 function button_cell($name, $value, $title=false, $icon=false, $aspect='')
 {
-	echo "<td align='center'>";
-	echo button($name, $value, $title, $icon, $aspect);
-	echo "</td>";
+	InputRenderer::get()->button_cell($name, $value, $title, $icon, $aspect);
 }
 
 function delete_button_cell($name, $value, $title=false)
 {
-	button_cell($name, $value, $title, ICON_DELETE);
+	InputRenderer::get()->delete_button_cell($name, $value, $title);
 }
 
 function edit_button_cell($name, $value, $title=false)
 {
-	button_cell($name, $value, $title, ICON_EDIT);
+	InputRenderer::get()->edit_button_cell($name, $value, $title);
 }
 
 function select_button_cell($name, $value, $title=false)
 {
-	button_cell($name, $value, $title, ICON_ADD, 'selector');
+	InputRenderer::get()->select_button_cell($name, $value, $title);
 }
 //-----------------------------------------------------------------------------------
 
 function check_value($name)
 {
-	if (!isset($_POST[$name]) || $_POST[$name]=='')
-		return 0;
-	return 1;
+	// TODO This function would be better off elsewhere CP 2014-11
+	return InputRenderer::get()->check_value($name);
 }
 
 function checkbox($label, $name, $value=null, $submit_on_change=false, $title=false)
 {
-  	global $Ajax;
-
-	$str = '';	
-
-	if ($label)
-		$str .= $label . "  ";
-	if ($submit_on_change !== false) {
-		if ($submit_on_change === true)
-			$submit_on_change = 
-				"JsHttpRequest.request(\"_{$name}_update\", this.form);";
-	}
-	if ($value === null)
-		$value = get_post($name,0);
-
-	$str .= "<input"
-	    .($value == 1 ? ' checked':'')
-	    ." type='checkbox' name='$name' value='1'"
-	    .($submit_on_change ? " onclick='$submit_on_change'" : '')
-	    .($title ? " title='$title'" : '')
-	    ." >\n";
-
-	$Ajax->addUpdate($name, $name, $value);
-	return $str;
+	return InputRenderer::get()->checkbox($label, $name, $value, $submit_on_change, $title);
 }
 
 function check($label, $name, $value=null, $submit_on_change=false, $title=false)
 {
-	echo checkbox($label, $name, $value, $submit_on_change, $title);
+	InputRenderer::get()->check($label, $name, $value, $submit_on_change, $title);
 }
 
-function check_cells($label, $name, $value=null, $submit_on_change=false, $title=false,
-	$params='')
+function check_cells($label, $name, $value=null, $submit_on_change=false, $title=false, $params='')
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td $params>";
-	echo check(null, $name, $value, $submit_on_change, $title);
-	echo "</td>";
+	InputRenderer::get()->check_cells($label, $name, $value, $submit_on_change, $title, $params);
 }
 
 function check_row($label, $name, $value=null, $submit_on_change=false, $title=false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	echo check_cells(NULL, $name, $value, $submit_on_change, $title);
-	echo "</tr>\n";
+	InputRenderer::get()->check_row($label, $name, $value, $submit_on_change, $title);
 }
 
 //-----------------------------------------------------------------------------------
 function radio($label, $name, $value, $selected=null, $submit_on_change=false)
 {
-	if (!isset($selected))
-		$selected = get_post($name) === (string)$value;
-
-	if ($submit_on_change === true)
-		$submit_on_change = 
-			"JsHttpRequest.request(\"_{$name}_update\", this.form);";
-
-	return "<input type='radio' name=$name value='$value' ".($selected ? "checked":'')
-	    .($submit_on_change ? " onclick='$submit_on_change'" : '')
-		.">".($label ? $label : '');
+	return InputRenderer::get()->radio($label, $name, $value, $selected, $submit_on_change);
 }
 
 //-----------------------------------------------------------------------------------
 function labelheader_cell($label, $params="")
 {
-	echo "<td class='tableheader' $params>$label</td>\n";
+	InputRenderer::get()->labelheader_cell($label, $params);
 }
 
 function label_cell($label, $params="", $id=null)
 {
-    global $Ajax;
-
-	if(isset($id))
-	{
-	    $params .= " id='$id'";
-	    $Ajax->addUpdate($id, $id, $label);
-	}
-	echo "<td $params>$label</td>\n";
-
-	return $label;
+	return InputRenderer::get()->label_cell($label, $params, $id);
 }
 
 function email_cell($label, $params="", $id=null)
 {
-	label_cell("<a href='mailto:$label'>$label</a>", $params, $id);
+	InputRenderer::get()->email_cell($label, $params, $id);
 }
 
 function amount_decimal_cell($label, $params="", $id=null)
 {
-	$dec = 0;
-	label_cell(price_decimal_format($label, $dec), "nowrap align=right ".$params, $id);
+	InputRenderer::get()->amount_decimal_cell($label, $params, $id);
 }
 
 function amount_cell($label, $bold=false, $params="", $id=null)
 {
-	if ($bold)
-		label_cell("<b>".price_format($label)."</b>", "nowrap align=right ".$params, $id);
-	else
-		label_cell(price_format($label), "nowrap align=right ".$params, $id);
+	InputRenderer::get()->amount_cell($label, $bold, $params, $id);
 }
 
 //JAM  Allow entered unit prices to be fractional
 function unit_amount_cell($label, $bold=false, $params="", $id=null)
 {
-	if ($bold)
-		label_cell("<b>".unit_price_format($label)."</b>", "nowrap align=right ".$params, $id);
-	else
-		label_cell(unit_price_format($label), "nowrap align=right ".$params, $id);
+	InputRenderer::get()->unit_amount_cell($label, $bold, $params, $id);
 }
-
 
 function percent_cell($label, $bold=false, $id=null)
 {
-	if ($bold)
-		label_cell("<b>".percent_format($label)."</b>", "nowrap align=right", $id);
-	else
-		label_cell(percent_format($label), "nowrap align=right", $id);
+	InputRenderer::get()->percent_cell($label, $bold, $id);
 }
 // 2008-06-15. Changed
 function qty_cell($label, $bold=false, $dec=null, $id=null)
 {
-	if (!isset($dec))
-		$dec = get_qty_dec();
-	if ($bold)
-		label_cell("<b>".number_format2($label, $dec)."</b>", "nowrap align=right", $id);
-	else
-		label_cell(number_format2($label, $dec), "nowrap align=right", $id);
+	InputRenderer::get()->qty_cell($label, $bold, $dec, $id);
 }
 
-function label_cells($label, $value, $params="", $params2="", $id=null)
+function label_cells($label, $value, $params="", $params2="", $id='')
 {
-	if ($label != null)
-		echo "<td $params>$label</td>\n";
-	label_cell($value, $params2, $id);
+	InputRenderer::get()->label_cells($label, $value, $params, $params2, $id);
 }
 
-function label_row($label, $value, $params="", $params2="", $leftfill=0, $id=null)
+function label_row($label, $value, $params="", $params2="", $leftfill=0, $id='')
 {
-	echo "<tr>";
-	if ($params == "")
-	{
-		echo "<td class='label'>$label</td>";
-		$label = null;
-	}	
-	label_cells($label, $value, $params, $params2, $id);
-	if ($leftfill!=0)
-	  	echo "<td colspan=$leftfill></td>";
-	echo "</tr>\n";
+	InputRenderer::get()->label_row($label, $value, $params, $params2, $leftfill, $id);
 }
 
 function text_input($name, $value=null, $size='', $max='', $title='', $params='')
 {
-	if ($value === null)
-		$value = get_post($name);
-
-	return "<input $params type=\"text\" name=\"$name\" size=\"$size\" maxlength=\"$max\" value=\"$value\""
-	    .($title ? " title='$title'" : '')
-	    .">";
+	InputRenderer::get()->text_input($name, $value, $size, $max, $title, $params);
 }
 
 //-----------------------------------------------------------------------------------
 
-function text_cells($label, $name, $value=null, $size="", $max="", $title=false, 
+function text_cells(
+	$label, $name, $value=null, $size="", $max="", $title=false,
 	$labparams="", $post_label="", $inparams="")
 {
-  	global $Ajax;
-
-	default_focus($name);
-	if ($label != null)
-		label_cell($label, $labparams);
-	echo "<td>";
-
-	echo text_input($name, $value, $size, $max, $title, $inparams);
-
-	if ($post_label != "")
-		echo " " . $post_label;
-
-	echo "</td>\n";
-	$Ajax->addUpdate($name, $name, $value);
+	InputRenderer::get()->text_cells($label, $name, $value, $size, $max, $title, $labparams, $post_label, $inparams);
 }
 
-function text_cells_ex($label, $name, $size, $max=null, $init=null, $title=null,
+function text_cells_ex(
+	$label, $name, $size, $max=null, $init=null, $title=null,
 	$labparams=null, $post_label=null, $submit_on_change=false)
 {
-  	global $Ajax;
-
-	default_focus($name);
-	if (!isset($_POST[$name]) || $_POST[$name] == "")
-	{
-		if ($init)
-			$_POST[$name] = $init;
-		else
-			$_POST[$name] = "";
-	}
-	if ($label != null)
-		label_cell($label, $labparams);
-
-	if (!isset($max))
-		$max = $size;
-
-	echo "<td>";
-	$class = $submit_on_change ? 'class="searchbox"' : '';
-	echo "<input $class type=\"text\" name=\"$name\" size=\"$size\" maxlength=\"$max\" value=\"" . $_POST[$name]. "\""
-	 .($title ? " title='$title'": '')." >";
-
-	if ($post_label)
-		echo " " . $post_label;
-
-	echo "</td>\n";
-	$Ajax->addUpdate($name, $name, $_POST[$name]);
+	InputRenderer::get()->text_cells_ex($label, $name, $size, $max, $init, $title, $labparams, $post_label, $submit_on_change);
 }
 
 function text_row($label, $name, $value, $size, $max, $title=null, $params="", $post_label="")
 {
-	echo "<tr><td class='label'>$label</td>";
-	text_cells(null, $name, $value, $size, $max, $title, $params, $post_label);
-
-	echo "</tr>\n";
+	InputRenderer::get()->text_row($label, $name, $value, $size, $max, $title, $params, $post_label);
 }
 
 //-----------------------------------------------------------------------------------
 
 function text_row_ex($label, $name, $size, $max=null, $title=null, $value=null, $params=null, $post_label=null)
 {
-	echo "<tr><td class='label'>$label</td>";
-	text_cells_ex(null, $name, $size, $max, $value, $title, $params, $post_label);
-
-	echo "</tr>\n";
+	InputRenderer::get()->text_row_ex($label, $name, $size, $max, $title, $value, $params, $post_label);
 }
 
 //-----------------------------------------------------------------------------------
 function email_row($label, $name, $value, $size, $max, $title=null, $params="", $post_label="")
 {
-	if (get_post($name)) 
-		$label = "<a href='Mailto:".$_POST[$name]."'>$label</a>";
-	text_row($label, $name, $value, $size, $max, $title, $params, $post_label);
+	InputRenderer::get()->email_row($label, $name, $value, $size, $max, $title, $params, $post_label);
 }
 
 function email_row_ex($label, $name, $size, $max=null, $title=null, $value=null, $params=null, $post_label=null)
 {
-	if (get_post($name)) 
-		$label = "<a href='Mailto:".$_POST[$name]."'>$label</a>";
-	text_row_ex($label, $name, $size, $max, $title, $value, $params, $post_label);
+	InputRenderer::get()->email_row_ex($label, $name, $size, $max, $title, $value, $params, $post_label);
 }
 
 function link_row($label, $name, $value, $size, $max, $title=null, $params="", $post_label="")
 {
-	$val = get_post($name);
-	if ($val) {
-		if (strpos($val,'http://')===false)
-			$val = 'http://'.$val;
-		$label = "<a href='$val' target='_blank'>$label</a>";
-	}
-	text_row($label, $name, $value, $size, $max, $title, $params, $post_label);
+	InputRenderer::get()->link_row($label, $name, $value, $size, $max, $title, $params, $post_label);
 }
 
 function link_row_ex($label, $name, $size, $max=null, $title=null, $value=null, $params=null, $post_label=null)
 {
-	$val = get_post($name);
-	if ($val) {
-		if (strpos($val,'http://')===false)
-			$val = 'http://'.$val;
-		$label = "<a href='$val' target='_blank'>$label</a>";
-	}
-	text_row_ex($label, $name, $size, $max, $title, $value, $params, $post_label);
+	InputRenderer::get()->link_row_ex($label, $name, $size, $max, $title, $val, $params, $post_label);
 }
 
 //-----------------------------------------------------------------------------------
 //
-//	Since FA 2.2  $init parameter is superseded by $check. 
-//  When $check!=null current date is displayed in red when set to other 
+//	Since FA 2.2  $init parameter is superseded by $check.
+//  When $check!=null current date is displayed in red when set to other
 //	than current date.
-//	
-function date_cells($label, $name, $title = null, $check=null, $inc_days=0, 
+//
+function date_cells(
+	$label, $name, $title = null, $check=null, $inc_days=0,
 	$inc_months=0, $inc_years=0, $params=null, $submit_on_change=false)
 {
-	global $path_to_root, $Ajax;
-
-	if (!isset($_POST[$name]) || $_POST[$name] == "")
-	{
-		if ($inc_years == 1001)
-			$_POST[$name] = null;
-		else
-		{
-			$dd = Today();
-			if ($inc_days != 0)
-				$dd = add_days($dd, $inc_days);
-			if ($inc_months != 0)
-				$dd = add_months($dd, $inc_months);
-			if ($inc_years != 0)
-				$dd = add_years($dd, $inc_years);
-			$_POST[$name] = $dd;
-		}
-	}
-	if (user_use_date_picker())
-	{
-		$calc_image = (file_exists("$path_to_root/themes/".user_theme()."/images/cal.gif")) ? 
-			"$path_to_root/themes/".user_theme()."/images/cal.gif" : "$path_to_root/themes/default/images/cal.gif";
-		$post_label = "<a tabindex='-1' href=\"javascript:date_picker(document.getElementsByName('$name')[0]);\">"
-		. "	<img src='$calc_image' style='vertical-align:middle;padding-bottom:4px;width:16px;height:16px;border:0;' alt='"._('Click Here to Pick up the date')."'></a>\n";
-	}	
-	else
-		$post_label = "";
-
-	if ($label != null)
-		label_cell($label, $params);
-
-	echo "<td>";
-	
-	$class = $submit_on_change ? 'date active' : 'date';
-
-	$aspect = $check ? 'aspect="cdate"' : '';
-	if ($check && (get_post($name) != Today()))
-		$aspect .= ' style="color:#FF0000"';
-
-	default_focus($name);
-	$size = (user_date_format()>3)?11:10; 
-	echo "<input type=\"text\" name=\"$name\" class=\"$class\" $aspect size=\"$size\" maxlength=\"12\" value=\"" 
-	 . $_POST[$name]. "\""
-	 .($title ? " title='$title'": '')." > $post_label";
-	echo "</td>\n";
-	$Ajax->addUpdate($name, $name, $_POST[$name]);
+	InputRenderer::get()->date_cells($label, $name, $title, $check, $inc_days, $inc_months, $inc_years, $params, $submit_on_change);
 }
 
-function date_row($label, $name, $title=null, $check=null, $inc_days=0, $inc_months=0, 
+function date_row(
+	$label, $name, $title=null, $check=null, $inc_days=0, $inc_months=0,
 	$inc_years=0, $params=null, $submit_on_change=false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	date_cells(null, $name, $title, $check, $inc_days, $inc_months, 
-		$inc_years, $params, $submit_on_change);
-	echo "</tr>\n";
+	InputRenderer::get()->date_row($label, $name, $check, $inc_days, $inc_months, $inc_years, $params, $submit_on_change);
 }
 
 //-----------------------------------------------------------------------------------
 function password_row($label, $name, $value)
 {
-	echo "<tr><td class='label'>$label</td>";
-	label_cell("<input type='password' name='$name' size=20 maxlength=20 value='$value' >");
-	echo "</tr>\n";
-}	
+	InputRenderer::get()->password_row($label, $name, $value);
+}
 
 //-----------------------------------------------------------------------------------
 function file_cells($label, $name, $id="")
 {
-	if ($id != "")
-		$id = "id='$id'";
-	label_cells($label, "<input type='file' name='$name' $id >");
-}		
+	InputRenderer::get()->file_cells($label, $name, $id);
+}
+
 function file_row($label, $name, $id = "")
 {
-	echo "<tr><td class='label'>$label</td>";
-	file_cells(null, $name, $id);
-	echo "</tr>\n";
-}	
-
-/*-----------------------------------------------------------------------------------
-
- Reference number input.
-
- Optional  $context array contains transaction data used in number parsing:
- 	'data' - data used for month/year codes
-	'location' - location code
- 	'customer' - debtor_no
- 	'supplier' - supplier id
- 	'branch' - branch_code
-*/
-function ref_cells($label, $name, $title=null, $init=null, $params=null, $submit_on_change=false, $type=null, $context=null)
-{
-	global $Ajax, $Refs;
-
-	if (isset($type)) {
-		if (empty($_POST[$name.'_list'])) // restore refline id
-			$_POST[$name.'_list'] = $Refs->reflines->find_refline_id(empty($_POST[$name]) ? $init : $_POST[$name], $type);
-
-		if (empty($_POST[$name]) || ($_SERVER['REQUEST_METHOD'] == 'GET')) // initialization
-		{
-			if (isset($init))
-			{
-				$_POST[$name] = $init;
-			} else {
-				$_POST[$name] = $Refs->get_next($type, $_POST[$name.'_list'], $context);
-			}
-			$Ajax->addUpdate(true, $name, $_POST[$name]);
-		}
-
-		if (check_ui_refresh($name)) { // call context changed
-			$_POST[$name] = $Refs->normalize($init, $type, $context, $_POST[$name.'_list']);
-			$Ajax->addUpdate(true, $name, $_POST[$name]);
-		}
-
-		if ($Refs->reflines->count($type)>1) {
-			if (list_updated($name.'_list')) {
-				$_POST[$name] = $Refs->get_next($type, $_POST[$name.'_list'], $context);
-				$Ajax->addUpdate(true, $name, $_POST[$name]);
-			}
-			$list = refline_list($name.'_list', $type);
-		} else {
-			$list = '';
-		}
-
-		if (isset($label))
-			label_cell($label, $params);
-
-		label_cell($list."<input name='".$name."' "
-			.(check_edit_access($name) ? '' : 'disabled ')
-			."value='".@$_POST[$name]."' size=10 maxlength=35>");
-	}
-	else // just wildcard ref field (e.g. for global inquires)
-	{
-		text_cells_ex($label, $name, 16, 35, $init, $title, $params, null, $submit_on_change);
-	}
+	InputRenderer::get()->file_row($label, $name, $id);
 }
 
 //-----------------------------------------------------------------------------------
 
-function ref_row($label, $name, $title=null, $init=null, $submit_on_change=false, $type=null, $context = null)
+function ref_cells($label, $name, $title=null, $init=null, $params=null, $submit_on_change=false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	ref_cells(null, $name, $title, $init, null, $submit_on_change, $type, $context);
-	echo "</tr>\n";
+	InputRenderer::get()->ref_cells($label, $name, $title, $init, $params, $submit_on_change);
+}
+
+//-----------------------------------------------------------------------------------
+
+function ref_row($label, $name, $title=null, $init=null, $submit_on_change=false)
+{
+	InputRenderer::get()->ref_row($label, $name, $title, $init, $submit_on_change);
 }
 
 //-----------------------------------------------------------------------------------
 
 function percent_row($label, $name, $init=null)
 {
-
-	if (!isset($_POST[$name]) || $_POST[$name]=="")
-	{
-		$_POST[$name] = $init == null ? '' : $init;
-	}
-
-	small_amount_row($label, $name, $_POST[$name], null, "%", user_percent_dec());
+	InputRenderer::get()->percent_row($label, $name, $init);
 }
 
 function amount_cells_ex($label, $name, $size, $max=null, $init=null, $params=null, $post_label=null, $dec=null)
 {
-	global $Ajax;
-
-	if (!isset($dec))
-	  	$dec = user_price_dec();
-	if (!isset($_POST[$name]) || $_POST[$name] == "")
-	{
-		if ($init !== null)
-			$_POST[$name] = $init;
-		else
-			$_POST[$name] = '';
-	}
-	if ($label != null)
-	{
-		if ($params == null)
-			$params = "class='label'";
-		label_cell($label, $params);
-	}
-	if (!isset($max))
-		$max = $size;
-
-	if ($label != null)
-		echo "<td>";
-	else
-		echo "<td align='right'>";
-
-	echo "<input class='amount' type=\"text\" name=\"$name\" size=\"$size\" maxlength=\"$max\" dec=\"$dec\" value=\"" . $_POST[$name]. "\">";
-
-	if ($post_label) {
-		echo "<span id='_{$name}_label'> $post_label</span>";
-		$Ajax->addUpdate($name, '_'.$name.'_label', $post_label);
-	}
-	echo "</td>\n";
-	$Ajax->addUpdate($name, $name, $_POST[$name]);
-	$Ajax->addAssign($name, $name, 'dec', $dec);
+	InputRenderer::get()->amount_cells_ex($label, $name, $size, $max, $init, $params, $post_label, $dec);
 }
 
 
@@ -832,192 +379,132 @@ function amount_cells_ex($label, $name, $size, $max=null, $init=null, $params=nu
 
 function amount_cells($label, $name, $init=null, $params=null, $post_label=null, $dec=null)
 {
-	amount_cells_ex($label, $name, 15, 15, $init, $params, $post_label, $dec);
+	InputRenderer::get()->amount_cells($label, $name, $init, $params, $post_label, $dec);
 }
 
 //JAM  Allow entered unit prices to be fractional
 function unit_amount_cells($label, $name, $init=null, $params=null, $post_label=null, $dec=null)
 {
-	if (!isset($dec))
-	  	$dec = user_price_dec()+2;
-
-	amount_cells_ex($label, $name, 15, 15, $init, $params, $post_label, $dec+2);
+	InputRenderer::get()->unit_amount_cells($label, $name, $init, $params, $post_label, $dec);
 }
 
 function amount_row($label, $name, $init=null, $params=null, $post_label=null, $dec=null)
 {
-	echo "<tr>";
-	amount_cells($label, $name, $init, $params, $post_label, $dec);
-	echo "</tr>\n";
+	InputRenderer::get()->amount_row($label, $name, $init, $params, $post_label, $dec);
 }
 
 function small_amount_row($label, $name, $init=null, $params=null, $post_label=null, $dec=null)
 {
-	echo "<tr>";
-	small_amount_cells($label, $name, $init, $params, $post_label, $dec);
-	echo "</tr>\n";
+	InputRenderer::get()->small_amount_row($label, $name, $init, $params, $post_label, $dec);
 }
 
 //-----------------------------------------------------------------------------------
 
 function qty_cells($label, $name, $init=null, $params=null, $post_label=null, $dec=null)
 {
-	if (!isset($dec))
-	  	$dec = user_qty_dec();
-
-	amount_cells_ex($label, $name, 15, 15, $init, $params, $post_label, $dec);
+	InputRenderer::get()->qty_cells($label, $name, $init, $params, $post_label, $dec);
 }
 
 function qty_row($label, $name, $init=null, $params=null, $post_label=null, $dec=null)
 {
-	if (!isset($dec))
-	  	$dec = user_qty_dec();
-
-	echo "<tr>";
-	amount_cells($label, $name, $init, $params, $post_label, $dec);
-	echo "</tr>\n";
+	InputRenderer::get()->qty_row($label, $name, $init, $params, $post_label, $dec);
 }
 
 function small_qty_row($label, $name, $init=null, $params=null, $post_label=null, $dec=null)
 {
-	if (!isset($dec))
-	  	$dec = user_qty_dec();
-
-	echo "<tr>";
-	small_amount_cells($label, $name, $init, $params, $post_label, $dec);
-	echo "</tr>\n";
+	InputRenderer::get()->small_qty_row($label, $name, $init, $params, $post_label, $dec);
 }
 
 //-----------------------------------------------------------------------------------
 
 function small_amount_cells($label, $name, $init=null, $params=null, $post_label=null, $dec=null)
 {
-	amount_cells_ex($label, $name, 7, 12, $init, $params, $post_label, $dec);
+	InputRenderer::get()->small_amount_cells($label, $name, $init, $params, $post_label, $dec);
 }
 
 //-----------------------------------------------------------------------------------
 
 function small_qty_cells($label, $name, $init=null, $params=null, $post_label=null, $dec=null)
 {
-  	if (!isset($dec))
-	  	$dec = user_qty_dec();
-	amount_cells_ex($label, $name, 7, 12, $init, $params, $post_label, $dec);
+	InputRenderer::get()->small_qty_cells($label, $name, $init, $params, $post_label, $dec);
 }
 
 //-----------------------------------------------------------------------------------
 
 function textarea_cells($label, $name, $value, $cols, $rows, $title = null, $params="")
 {
-  	global $Ajax;
-
-	default_focus($name);
-	if ($label != null)
-		echo "<td $params>$label</td>\n";
-	if ($value == null)
-		$value = (!isset($_POST[$name]) ? "" : $_POST[$name]);
-	echo "<td><textarea name='$name' cols='$cols' rows='$rows'"
-	.($title ? " title='$title'" : '')
-	.">$value</textarea></td>\n";
-	$Ajax->addUpdate($name, $name, $value);
+	InputRenderer::get()->textarea_cells($label, $name, $value, $cols, $rows, $title, $params);
 }
 
 function textarea_row($label, $name, $value, $cols, $rows, $title=null, $params="")
 {
-	echo "<tr><td class='label'>$label</td>";
-	textarea_cells(null, $name, $value, $cols, $rows, $title, $params);
-	echo "</tr>\n";
+	InputRenderer::get()->textarea_row($label, $name, $value, $cols, $rows, $title, $params);
 }
 
 //-----------------------------------------------------------------------------------
+/*
+function text_row_with_submit($label, $name, $value, $size, $max, $input_name, $input_value)
+{
+  	global $Ajax;
+
+	default_focus($name);
+	echo "<tr><td>$label</td>\n";
+	echo "<td>";
+
+	if ($value == null)
+		$value = (!isset($_POST[$name]) ? "" : $_POST[$name]);
+	echo "<input type=\"text\" name=\"$name\" size=\"$size\" maxlength=\"$max\" value=\"$value\">   ";
+
+	submit($input_name, $input_value);
+
+	echo "</td></tr>\n";
+	$Ajax->addUpdate($name, $name, $value);
+}
+*/
+//-----------------------------------------------------------------------------------
 //
-//	When show_inactive page option is set 
+//	When show_inactive page option is set
 //  displays value of inactive field as checkbox cell.
 //  Also updates database record after status change.
 //
 function inactive_control_cell($id, $value, $table, $key)
 {
-	global	$Ajax;
-
-	$name = "Inactive". $id;
-	$value = $value ? 1:0;
-
-	if (check_value('show_inactive')) {
-		if (isset($_POST['LInact'][$id]) && (get_post('_Inactive'.$id.'_update') || 
-			get_post('Update')) && (check_value('Inactive'.$id) != $value)) {
-			update_record_status($id, !$value, $table, $key);
-		}
-		echo '<td align="center">'. checkbox(null, $name, $value, true, '')
- 			. hidden("LInact[$id]", $value, false) . '</td>';	
-	}
+	InputRenderer::get()->inactive_control_cell($id, $value, $table, $key);
 }
 //
 //	Displays controls for optional display of inactive records
 //
 function inactive_control_row($th) {
-	echo  "<tr><td colspan=".(count($th)).">"
-		."<div style='float:left;'>"
-		. checkbox(null, 'show_inactive', null, true). _("Show also Inactive")
-		."</div><div style='float:right;'>"
-		. submit('Update', _('Update'), false, '', null)
-		."</div></td></tr>";
+	InputRenderer::get()->inactive_control_row($th);
 }
 //
 //	Inserts additional column header when display of inactive records is on.
 //
 function inactive_control_column(&$th) {
-	global $Ajax;
-	
-	if (check_value('show_inactive')) 
-		array_insert($th, count($th)-2 , _("Inactive"));
-	if (get_post('_show_inactive_update')) {
-		$Ajax->activate('_page_body');
-	}
+	InputRenderer::get()->inactive_control_column($th);
 }
 
 function customer_credit_row($customer, $credit, $parms='')
 {
-	global $path_to_root;
-	
-	label_row( _("Current Credit:"),
-		"<a target='_blank' " . ($credit<0 ? 'class="redfg"' : '')
-		."href='$path_to_root/sales/inquiry/customer_inquiry.php?customer_id=".$customer."'"
-		." onclick=\"javascript:openWindow(this.href,this.target); return false;\" >"
-		. price_format($credit)
-		."</a>", $parms);
+	InputRenderer::get()->customer_credit_row($customer, $credit, $parms);
 }
 
 function supplier_credit_row($supplier, $credit, $parms='')
 {
-	global $path_to_root;
-	
-	label_row( _("Current Credit:"),
-		"<a target='_blank' " . ($credit<0 ? 'class="redfg"' : '')
-		."href='$path_to_root/purchasing/inquiry/supplier_inquiry.php?supplier_id=".$supplier."'"
-		." onclick=\"javascript:openWindow(this.href,this.target); return false;\" >"
-		. price_format($credit)
-		."</a>", $parms);
+	InputRenderer::get()->supplier_credit_row($supplier, $credit, $parms);
 }
 
 function bank_balance_row($bank_acc, $parms='')
 {
-	global $path_to_root;
-
-	$to = add_days(Today(), 1);
-	$bal = get_balance_before_for_bank_account($bank_acc, $to);
-	label_row( _("Bank Balance:"),
-		"<a target='_blank' " . ($bal<0 ? 'class="redfg"' : '')
-		."href='$path_to_root/gl/inquiry/bank_inquiry.php?bank_account=".$bank_acc."'"
-		." onclick=\"javascript:openWindow(this.href,this.target); return false;\" >&nbsp;"
-		. price_format($bal)
-		."</a>", $parms);
+	InputRenderer::get()->bank_balance_row($bank_acc, $parms);
 }
 
 function ahref($label, $href, $target="", $onclick="") {
-  echo "<a href='$href' target='$target' onclick='$onclick'>$label</a>";
+	InputRenderer::get()->ahref($label, $href, $target, $onclick);
 }
 
 function ahref_cell($label, $href, $target="", $onclick="") {
-  echo "<td align='center'>&nbsp;&nbsp;";
-  ahref($label, $href, $target, $onclick);
-  echo "&nbsp;&nbsp;</td>";
+	InputRenderer::get()->ahref_cell($label, $href, $target, $onclick);
 }
+
+?>

--- a/includes/ui/ui_lists.inc
+++ b/includes/ui/ui_lists.inc
@@ -1,1513 +1,514 @@
 <?php
 /**********************************************************************
     Copyright (C) FrontAccounting, LLC.
-	Released under the terms of the GNU General Public License, GPL, 
-	as published by the Free Software Foundation, either version 3 
+	Released under the terms of the GNU General Public License, GPL,
+	as published by the Free Software Foundation, either version 3
 	of the License, or (at your option) any later version.
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
     See the License here <http://www.gnu.org/licenses/gpl-3.0.html>.
 ***********************************************************************/
-include_once($path_to_root . "/includes/banking.inc");
-include_once($path_to_root . "/includes/types.inc");
-include_once($path_to_root . "/includes/current_user.inc");
+include_once ($path_to_root . "/includes/ui/ListRenderer.inc");
 
+// TODO Move these variables inside the ListRenderer constructor. CP 2014-11
 define('SEARCH_BUTTON', "<input %s type='submit' class='combo_submit' style='border:0;background:url($path_to_root/themes/"
 	."%s/images/locate.png) no-repeat;%s' aspect='fallback' name='%s' value=' ' title='"._("Set filter")."'> ");
 
 define('SELECT_BUTTON', "<input %s type='submit' class='combo_select' style='border:0;background:url($path_to_root/themes/"
 	."%s/images/button_ok.png) no-repeat;%s' aspect='fallback' name='%s' value=' ' title='"._("Select")."'> ");
 
-//----------------------------------------------------------------------------
-//	Universal sql combo generator
-//	$sql must return selector values and selector texts in columns 0 & 1
-//	Options are merged with defaults.
+/*
+ * Note that the order of instantiation of the above strings (in the overall context) was important.
+ * When these strings were in ListRenderer.inc the XHR request on combo boxes stopped working.
+ * I suspect when moved into say the ListRenderer class and instantiated from the constructor they
+ * will be fine. CP 2014-11
+ */
 
-function combo_input($name, $selected_id, $sql, $valfield, $namefield,
-	$options=null, $type=null)
+// ----------------------------------------------------------------------------
+// Universal sql combo generator
+// $sql must return selector values and selector texts in columns 0 & 1
+// Options are merged with defaults.
+function combo_input($name, $selected_id, $sql, $valfield, $namefield, $options = null)
 {
-global $Ajax, $path_to_root, $SysPrefs ;
-
-$opts = array(		// default options
-	'where'=> array(),		// additional constraints
-	'order' => $namefield,	// list sort order
-		// special option parameters
-	'spec_option'=>false, 	// option text or false
-	'spec_id' => 0,		// option id
-		// submit on select parameters
-	'default' => '', // default value when $_POST is not set
-	'multi' => false,	// multiple select
-	'select_submit' => false, //submit on select: true/false
-	'async' => true,	// select update via ajax (true) vs _page_body reload
-		// search box parameters
-	'sel_hint' => null,
-	'search_box' => false, 	// name or true/false
-	'type' => 0,	// type of extended selector:
-		// 0 - with (optional) visible search box, search by fragment inside id
-		// 1 - with hidden search box, search by option text
-		// 2 - with (optional) visible search box, search by fragment at the start of id
-		// 3 - TODO reverse: box with hidden selector available via enter; this
-		// would be convenient for optional ad hoc adding of new item
-	'search_submit' => true, //search submit button: true/false
-	'size' => 8,	// size and max of box tag
-	'max' => 50,
-	'height' => false,	// number of lines in select box
-	'cells' => false,	// combo displayed as 2 <td></td> cells
-	'search' => array(), // sql field names to search
-	'format' => null, 	 // format functions for regular options
-	'disabled' => false,
-	'box_hint' => null, // box/selectors hints; null = std see below
-	'category' => false, // category column name or false
-	'show_inactive' => false, // show inactive records. 
-	'editable' => false, // false, or length of editable entry field
-	'editlink' => false	// link to entity entry/edit page (optional)
-);
-// ------ merge options with defaults ----------
-	if($options != null)
-		$opts = array_merge($opts, $options);
-	if (!is_array($opts['where']))  $opts['where'] = array($opts['where']);
-
-	$search_box = $opts['search_box']===true ? '_'.$name.'_edit' : $opts['search_box'];
-	// select content filtered by search field:
-	$search_submit = $opts['search_submit']===true ? '_'.$name.'_button' : $opts['search_submit'];
-	// select set by select content field
-	$search_button = $opts['editable'] ? '_'.$name.'_button' : ($search_box ? $search_submit : false);
-
-	$select_submit =  $opts['select_submit'];
-	$spec_id = $opts['spec_id'];
-	$spec_option = $opts['spec_option'];
-	if ($opts['type'] == 0) {
-		$by_id = true;
-		$class = 'combo';
-	} elseif($opts['type'] == 1) {
-		$by_id = false;
-		$class = 'combo2';
-	} else {
-		$by_id = true;
-		$class = 'combo3';
-	}
-
-	$disabled = $opts['disabled'] ? "disabled" : '';
-	$multi = $opts['multi'];
-	
-	if(!count($opts['search'])) {
-		$opts['search'] = array($by_id ? $valfield : $namefield);
-	}
-	if ($opts['sel_hint'] === null) 
-		$opts['sel_hint'] = $by_id || $search_box==false ?
-			'' : _('Press Space tab for search pattern entry');
-
-	if ($opts['box_hint'] === null)
-		$opts['box_hint'] = $search_box && $search_submit != false ?
-			($by_id ? _('Enter code fragment to search or * for all')
-			: _('Enter description fragment to search or * for all')) :'';
-
-	if ($selected_id == null) {
-		$selected_id = get_post($name, (string)$opts['default']);
-	}
-	if(!is_array($selected_id))
-		$selected_id = array((string)$selected_id); // code is generalized for multiple selection support
-
-	$txt = get_post($search_box);
-	$rel = '';
-	$limit = '';
-	if (isset($_POST['_'.$name.'_update'])) { // select list or search box change
-		if ($by_id) $txt = $_POST[$name];
-
-		if (!$opts['async'])
-			$Ajax->activate('_page_body');
-		else
-			$Ajax->activate($name);
-	}
-	if (isset($_POST[$search_button])) {
-		if (!$opts['async'])
-			$Ajax->activate('_page_body');
-		else
-			$Ajax->activate($name);
-	}
-	if ($search_box) {
-		// search related sql modifications
-
-		$rel = "rel='$search_box'"; // set relation to list
-		if ($opts['search_submit']) {
-			if (isset($_POST[$search_button])) {
-				$selected_id = array(); // ignore selected_id while search
-				if (!$opts['async'])
-					$Ajax->activate('_page_body');
-				else
-					$Ajax->activate($name);
-			}
-			if ($txt == '') {
-				if ($spec_option === false && $selected_id == array())
-					$limit = ' LIMIT 1';
-				else
-					$opts['where'][] = $valfield . "=". db_escape(get_post($name, $spec_id));
-			}
-			else
-				if ($txt != '*') {
-
-					foreach($opts['search'] as $i=> $s)
-						$opts['search'][$i] = $s . " LIKE "
-							.db_escape(($class=='combo3' ? '' : '%').$txt.'%');
-					$opts['where'][] = '('. implode($opts['search'], ' OR ') . ')';
-				}
-		}
-	}
-
-	// sql completion
-	if (count($opts['where'])) {
-		$where = strpos($sql, 'WHERE')==false ? ' WHERE ':' AND ';
-		$where .= '('. implode($opts['where'], ' AND ') . ')';
-		$group_pos = strpos($sql, 'GROUP BY');
-		if ($group_pos) {
-			$group = substr($sql, $group_pos);
-			$sql = substr($sql, 0, $group_pos) . $where.' '.$group;
-		} else {
-			$sql .= $where;
-		}
-	}
-	if ($opts['order'] != false) {
-		if (!is_array($opts['order']))
-			$opts['order'] = array($opts['order']);
-		$sql .= ' ORDER BY '.implode(',',$opts['order']);
-	}
-
-	$sql .= $limit;
-	// ------ make selector ----------
-	$selector = $first_opt = '';
-	$first_id = false;
-	$found = false;
-	$lastcat = null;
-	$edit = false;
-	if($result = db_query($sql)) {
-		while ($contact_row = db_fetch($result)) {
-			$value = $contact_row[0];
-			$descr = $opts['format']==null ?  $contact_row[1] :
-				call_user_func($opts['format'], $contact_row);
-			$sel = '';
- 		 	if (get_post($search_button) && ($txt == $value)) {
- 		 		$selected_id[] = $value;
- 		 	}
-
- 		 	if (in_array((string)$value, $selected_id, true)) {
-				$sel = 'selected';
-				$found = $value;
-				$edit = $opts['editable'] && $contact_row['editable'] 
-					&& (@$_POST[$search_box] == $value)
-					? $contact_row[1] : false; // get non-formatted description
-				if ($edit)
-					break;	// selected field is editable - abandon list construction
-			}
-			// show selected option even if inactive 
-			if (!$opts['show_inactive'] && @$contact_row['inactive'] && $sel==='') {
-				continue;
-			} else 
-				$optclass = @$contact_row['inactive'] ? "class='inactive'" : '';
-
-			if ($first_id === false) {
-				$first_id = $value;
-				$first_opt = $descr;
-			}
-			$cat = $contact_row[$opts['category']];
-			if ($opts['category'] !== false && $cat != $lastcat){
-				if ($lastcat!==null)
-					$selector .= "</optgroup>";
-				$selector .= "<optgroup label='".$cat."'>\n";
-				$lastcat = $cat;
-			}
-			$selector .= "<option $sel $optclass value='$value'>$descr</option>\n";
-		}
-		if ($lastcat!==null)
-			$selector .= "</optgroup>";
-		db_free_result($result);
-	}
-
-	// Prepend special option.
-	if ($spec_option !== false) { // if special option used - add it
-		$first_id = $spec_id;
-		$first_opt = $spec_option;
-		$sel = $found===false ? 'selected' : '';
-		$optclass = @$contact_row['inactive'] ? "class='inactive'" : '';
-		$selector = "<option $sel value='$first_id'>$first_opt</option>\n"
-			. $selector;
-	}
-
-	if ($found===false) {
-		$selected_id = array($first_id);
-	}
-	
-	$_POST[$name] = $multi ? $selected_id : $selected_id[0];
-
-	if ($SysPrefs->use_popup_search)
-		$selector = "<select id='$name' autocomplete='off' ".($multi ? "multiple" : '')
-		. ($opts['height']!==false ? ' size="'.$opts['height'].'"' : '')
-		. "$disabled name='$name".($multi ? '[]':'')."' class='$class' title='"
-		. $opts['sel_hint']."' $rel>".$selector."</select>\n";
-	else
-		$selector = "<select autocomplete='off' ".($multi ? "multiple" : '')
-		. ($opts['height']!==false ? ' size="'.$opts['height'].'"' : '')
-		. "$disabled name='$name".($multi ? '[]':'')."' class='$class' title='"
-		. $opts['sel_hint']."' $rel>".$selector."</select>\n";
-	if ($by_id && ($search_box != false || $opts['editable']) ) {
-		// on first display show selector list
-		if (isset($_POST[$search_box]) && $opts['editable'] && $edit) {
-			$selector = "<input type='hidden' name='$name' value='".$_POST[$name]."'>"
-			."<input type='text' $disabled name='{$name}_text' id='{$name}_text' size='".
-				$opts['editable']."' maxlength='".$opts['max']."' $rel value='$edit'>\n";
-				set_focus($name.'_text'); // prevent lost focus
-		} else if (get_post($search_submit ? $search_submit : "_{$name}_button"))
-			set_focus($name); // prevent lost focus
-		if (!$opts['editable'])
-	 		$txt = $found;
-		$Ajax->addUpdate($name, $search_box, $txt ? $txt : '');
-	}
-
-	$Ajax->addUpdate($name, "_{$name}_sel", $selector);
-
-	// span for select list/input field update
-	$selector = "<span id='_{$name}_sel'>".$selector."</span>\n";
-
-	 // if selectable or editable list is used - add select button
-	if ($select_submit != false || $search_button) {
-	// button class selects form reload/ajax selector update
-		$selector .= sprintf(SELECT_BUTTON, $disabled, user_theme(),
-			(fallback_mode() ? '' : 'display:none;'),
-			 '_'.$name.'_update')."\n";
-	}
-// ------ make combo ----------
-	$edit_entry = '';
-	if ($search_box != false) {
-		$edit_entry = "<input $disabled type='text' name='$search_box' id='$search_box' size='".
-			$opts['size']."' maxlength='".$opts['max'].
-			"' value='$txt' class='$class' rel='$name' autocomplete='off' title='"
-			.$opts['box_hint']."'"
-			.(!fallback_mode() && !$by_id ? " style=display:none;":'')
-			.">\n";
-		if ($search_submit != false || $opts['editable']) {
-			$edit_entry .= sprintf(SEARCH_BUTTON, $disabled, user_theme(),
-				(fallback_mode() ? '' : 'display:none;'),
-				$search_submit ? $search_submit : "_{$name}_button")."\n";
-		}
-	}
-	default_focus(($search_box && $by_id) ? $search_box : $name);
-
-	$img = "";
-	if ($SysPrefs->use_popup_search && (!isset($opts['fixed_asset']) || !$opts['fixed_asset']))
-	{
-		$img_title = "";
-		$link = "";
-  		$id = $name;
-  		if ($SysPrefs->use_popup_windows) {
-    		switch (strtolower($type)) {
-      			case "stock":
-        			$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=all&client_id=" . $id;
-        			$img_title = _("Search items");
-        			break;
-      			case "stock_manufactured":
-        			$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=manufactured&client_id=" . $id;
-        			$img_title = _("Search items");
-        			break;
-      			case "stock_purchased":
-        			$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=purchasable&client_id=" . $id;
-        			$img_title = _("Search items");
-        			break;
-      			case "stock_sales":
-        			$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=sales&client_id=" . $id;
-        			$img_title = _("Search items");
-        			break;
-      			case "stock_costable":
-        			$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=costable&client_id=" . $id;
-        			$img_title = _("Search items");
-        			break;
-      			case "component":
-      				$parent = $opts['parent'];
-        			$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=component&parent=".$parent."&client_id=" . $id;
-        			$img_title = _("Search items");
-        			break;
-      			case "kits":
-        			$link = $path_to_root . "/inventory/inquiry/stock_list.php?popup=1&type=kits&client_id=" . $id;
-        			$img_title = _("Search items");
-        			break;
-      			case "customer":
-        			$link = $path_to_root . "/sales/inquiry/customers_list.php?popup=1&client_id=" . $id;
-        			$img_title = _("Search customers");
-        			break;
-      			case "branch":
-        			$link = $path_to_root . "/sales/inquiry/customer_branches_list.php?popup=1&client_id=" . $id . "#customer_id";
-        			$img_title = _("Search branches");
-        			break;
-      			case "supplier":
-        			$link = $path_to_root . "/purchasing/inquiry/suppliers_list.php?popup=1&client_id=" . $id;
-        			$img_title = _("Search suppliers");
-        			break;
-      			case "account":
-        			$link = $path_to_root . "/gl/inquiry/accounts_list.php?popup=1&client_id=" . $id;
-        			$img_title = _("Search GL accounts");
-        			break;
-    		}
-  		}
-
-  		if ($link !=="") {
-    		$theme = user_theme();
-    		$img = '<img src="'.$path_to_root.'/themes/'.$theme.'/images/'.ICON_VIEW.
-    			'" style="vertical-align:middle;width:12px;height:12px;border:0;" onclick="javascript:lookupWindow(&quot;'.
-    			$link.'&quot;, &quot;&quot;);" title="' . $img_title . '" style="cursor:pointer;" />';
-  		}
-	}
-
-	if ($opts['editlink'])
-		$selector .= ' '.$opts['editlink'];
-
-	if ($search_box && $opts['cells'])
-		$str = ($edit_entry!='' ? "<td>$edit_entry</td>" : '')."<td>$selector$img</td>";
-	else
-		$str = $edit_entry.$selector.$img;
-	return $str;
+	return ListRenderer::get()->combo_input($name, $selected_id, $sql, $valfield, $namefield, $options);
 }
 
 /*
-	Helper function.
-	Returns true if selector $name is subject to update.
-*/
+ * Helper function. Returns true if selector $name is subject to update.
+ */
 function list_updated($name)
 {
-	return isset($_POST['_'.$name.'_update']) || isset($_POST['_'.$name.'_button']);
+	return ListRenderer::get()->list_updated($name);
 }
-//----------------------------------------------------------------------------------------------
-//	Universal array combo generator
-//	$items is array of options 'value' => 'description'
-//	Options is reduced set of combo_selector options and is merged with defaults.
 
-function array_selector($name, $selected_id, $items, $options=null)
+// ----------------------------------------------------------------------------------------------
+// Universal array combo generator
+// $items is array of options 'value' => 'description'
+// Options is reduced set of combo_selector options and is merged with defaults.
+function array_selector($name, $selected_id, $items, $options = null)
 {
-	global $Ajax;
-
-$opts = array(		// default options
-	'spec_option'=>false, 	// option text or false
-	'spec_id' => 0,		// option id
-	'select_submit' => false, //submit on select: true/false
-	'async' => true,	// select update via ajax (true) vs _page_body reload
-	'default' => '', // default value when $_POST is not set
-	'multi'=>false,	// multiple select
-		// search box parameters
-	'height' => false,	// number of lines in select box
-	'sel_hint' => null,
-	'disabled' => false
-);
-// ------ merge options with defaults ----------
-	if($options != null)
-		$opts = array_merge($opts, $options);
-	$select_submit =  $opts['select_submit'];
-	$spec_id = $opts['spec_id'];
-	$spec_option = $opts['spec_option'];
-	$disabled = $opts['disabled'] ? "disabled" : '';
-	$multi = $opts['multi'];
-
-	if ($selected_id == null) {
-		$selected_id = get_post($name, $opts['default']);
-	}
-	if(!is_array($selected_id))
-		$selected_id = array((string)$selected_id); // code is generalized for multiple selection support
-
-	if (isset($_POST[ '_'.$name.'_update'])) {
-		if (!$opts['async'])
-			$Ajax->activate('_page_body');
-		else
-			$Ajax->activate($name);
-	}
-
-	// ------ make selector ----------
-	$selector = $first_opt = '';
-	$first_id = false;
-	$found = false;
-	foreach($items as $value=>$descr) {
-		$sel = '';
-		if (in_array((string)$value, $selected_id, true)) {
-			$sel = 'selected';
-			$found = $value;
-		}
-		if ($first_id === false) {
-			$first_id = $value;
-			$first_opt = $descr;
-		}
-		$selector .= "<option $sel value='$value'>$descr</option>\n";
-	}
-
-	if ($first_id!==false) {
-		$sel = ($found===$first_id) || ($found===false && ($spec_option===false)) ? "selected='selected'" : '';
-	}
-	// Prepend special option.
-	if ($spec_option !== false) { // if special option used - add it
-		$first_id = $spec_id;
-		$first_opt = $spec_option;
-		$sel = $found===false ? 'selected' : '';
-		$selector = "<option $sel value='$spec_id'>$spec_option</option>\n"
-			. $selector;
-	}
-
-	if ($found===false) {
-		$selected_id = array($first_id);
-	}
-	$_POST[$name] = $multi ? $selected_id : $selected_id[0];
-
-	$selector = "<select autocomplete='off' ".($multi  ? "multiple" : '')
-		. ($opts['height']!==false ? ' size="'.$opts['height'].'"' : '')
-		. "$disabled name='$name".($multi ? '[]' : '')."' class='combo' title='"
-		. $opts['sel_hint']."'>".$selector."</select>\n";
-
-	$Ajax->addUpdate($name, "_{$name}_sel", $selector);
-
-	$selector = "<span id='_{$name}_sel'>".$selector."</span>\n";
-
-	if ($select_submit != false) { // if submit on change is used - add select button
-		$selector .= sprintf(SELECT_BUTTON, $disabled, user_theme(),
-			(fallback_mode() ? '' : 'display:none;'),
-			 '_'.$name.'_update')."\n";
-	}
-	default_focus($name);
-
-	return $selector;
+	return ListRenderer::get()->array_selector($name, $selected_id, $items, $options);
 }
-//----------------------------------------------------------------------------------------------
+// ----------------------------------------------------------------------------------------------
 function array_selector_row($label, $name, $selected_id, $items, $options=null)
 {
-	echo "<tr><td class='label'>$label</td>\n<td>";
-	echo array_selector($name, $selected_id, $items, $options);
-	echo "</td></tr>\n";
+	ListRenderer::get()->array_selector_row($label, $name, $selected_id, $items, $options);
 }
 
 //----------------------------------------------------------------------------------------------
 function _format_add_curr($row)
 {
-	static $company_currency;
-
-	if ($company_currency == null)
-	{
-		$company_currency = get_company_currency();
-	}
-	return $row[1] . ($row[2] == $company_currency ?
-		'' : ("&nbsp;-&nbsp;" . $row[2]));
+	return ListRenderer::get()->_format_add_curr($row);
 }
 
 function add_edit_combo($type)
 {
-	global $path_to_root, $popup_editors, $SysPrefs;
-
-	if (!isset($SysPrefs->use_icon_for_editkey) || $SysPrefs->use_icon_for_editkey==0)
-		return "";
-	// Derive theme path
-	$theme_path = $path_to_root . '/themes/' . user_theme();
-
-	$key = $popup_editors[$type][1];
-	$onclick = "onclick=\"javascript:callEditor($key); return false;\"";
-	$img = "<img width='12' height='12' border='0' alt='Add/Edit' title='Add/Edit' src='$theme_path/images/".ICON_EDIT."'>";
-	return "<a target = '_blank' href='#' $onclick tabindex='-1'>$img</a>"; 
+	return ListRenderer::get()->add_edit_combo($type);
 }
 
-function supplier_list($name, $selected_id=null, $spec_option=false, $submit_on_change=false,
-	$all=false, $editkey = false)
+function supplier_list($name, $selected_id = null, $spec_option = false, $submit_on_change = false, $all = false, $editkey = false)
 {
-
-	$sql = "SELECT supplier_id, supp_ref, curr_code, inactive FROM ".TB_PREF."suppliers ";
-
-	$mode = get_company_pref('no_supplier_list');
-
-	if ($editkey)
-		set_editor('supplier', $name, $editkey);
-
-	$ret = combo_input($name, $selected_id, $sql, 'supplier_id', 'supp_name',
-	array(
-		'format' => '_format_add_curr',
-	    'order' => array('supp_ref'),
-		'search_box' => $mode!=0,
-		'type' => 1,
-        'search' => array("supp_ref","supp_name","gst_no"),        
-		'spec_option' => $spec_option === true ? _("All Suppliers") : $spec_option,
-		'spec_id' => ALL_TEXT,
-		'select_submit'=> $submit_on_change,
-		'async' => false,
-		'sel_hint' => $mode ? _('Press Space tab to filter by name fragment') :
-		_('Select supplier'),
-		'show_inactive'=>$all,
-		'editlink' => $editkey ? add_edit_combo('supplier') : false
-		), "supplier");
-	return $ret;
+	return ListRenderer::get()->supplier_list($name, $selected_id, $spec_option, $submit_on_change, $all, $editkey);
 }
 
-function supplier_list_cells($label, $name, $selected_id=null, $all_option=false, 
-	$submit_on_change=false, $all=false, $editkey = false)
+function supplier_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $all = false, $editkey = false)
 {
-	if ($label != null)
-		echo "<td>$label</td><td>\n";
-		echo supplier_list($name, $selected_id, $all_option, $submit_on_change, 
-		$all, $editkey);
-		echo "</td>\n";
+	return ListRenderer::get()->supplier_list_cells($label, $name, $selected_id, $all_option, $submit_on_change, $all, $editkey);
 }
 
-function supplier_list_row($label, $name, $selected_id=null, $all_option = false, 
-	$submit_on_change=false, $all=false, $editkey = false)
+function supplier_list_row($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $all = false, $editkey = false)
 {
-	echo "<tr><td class='label'>$label</td><td>";
-	echo supplier_list($name, $selected_id, $all_option, $submit_on_change,
-		$all, $editkey);
-	echo "</td></tr>\n";
-}
-//----------------------------------------------------------------------------------------------
-
-function customer_list($name, $selected_id=null, $spec_option=false, $submit_on_change=false, 
-	$show_inactive=false, $editkey = false)
-{
-
-	$sql = "SELECT debtor_no, debtor_ref, curr_code, inactive FROM ".TB_PREF."debtors_master ";
-
-	$mode = get_company_pref('no_customer_list');
-
-	if ($editkey)
-		set_editor('customer', $name, $editkey);
-
-	$ret = combo_input($name, $selected_id, $sql, 'debtor_no', 'debtor_ref',
-	array(
-	    'format' => '_format_add_curr',
-	    'order' => array('debtor_ref'),
-		'search_box' => $mode!=0,
-		'type' => 1,
-		'size' => 20,
-        'search' => array("debtor_ref","name","tax_id"),        
-		'spec_option' => $spec_option === true ? _("All Customers") : $spec_option,
-		'spec_id' => ALL_TEXT,
-		'select_submit'=> $submit_on_change,
-		'async' => false,
-		'sel_hint' => $mode ? _('Press Space tab to filter by name fragment; F2 - entry new customer') :
-		_('Select customer'),
-		'show_inactive' => $show_inactive,
-		'editlink' => $editkey ? add_edit_combo('customer') : false
-	), "customer" );
-	return $ret;
+	return ListRenderer::get()->supplier_list_row($label, $name, $selected_id, $all_option, $submit_on_change, $all, $editkey);
 }
 
-function customer_list_cells($label, $name, $selected_id=null, $all_option=false, 
-	$submit_on_change=false, $show_inactive=false, $editkey = false)
+// ----------------------------------------------------------------------------------------------
+function customer_list($name, $selected_id = null, $spec_option = false, $submit_on_change = false, $show_inactive = false, $editkey = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td nowrap>";
-	echo customer_list($name, $selected_id, $all_option, $submit_on_change,
-		$show_inactive, $editkey);
-	echo "</td>\n";
+	return ListRenderer::get()->customer_list($name, $selected_id, $spec_option, $submit_on_change, $show_inactive, $editkey);
 }
 
-function customer_list_row($label, $name, $selected_id=null, $all_option = false, 
-	$submit_on_change=false, $show_inactive=false, $editkey = false)
+function customer_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $show_inactive = false, $editkey = false)
 {
-
-	echo "<tr><td class='label'>$label</td><td nowrap>";
-	echo customer_list($name, $selected_id, $all_option, $submit_on_change,
-		$show_inactive, $editkey);
-	echo "</td>\n</tr>\n";
+	return ListRenderer::get()->customer_list_cells($label, $name, $selected_id, $all_option, $submit_on_change, $show_inactive, $editkey);
 }
 
-//------------------------------------------------------------------------------------------------
-
-function customer_branches_list($customer_id, $name, $selected_id=null,
-	$spec_option = true, $enabled=true, $submit_on_change=false, $editkey = false)
+function customer_list_row($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $show_inactive = false, $editkey = false)
 {
-
-	$sql = "SELECT branch_code, branch_ref FROM ".TB_PREF."cust_branch
-		WHERE debtor_no=" . db_escape($customer_id)." ";
-
-	if ($editkey)
-		set_editor('branch', $name, $editkey);
-
-	$where = $enabled ? array("inactive = 0") : array();
-	$ret = combo_input($name, $selected_id, $sql, 'branch_code', 'branch_ref',
-	array(
-		'where' => $where,
-		'order' => array('branch_ref'),
-		'spec_option' => $spec_option === true ? _('All branches') : $spec_option,
-		'spec_id' => ALL_TEXT,
-		'select_submit'=> $submit_on_change,
-		'sel_hint' => _('Select customer branch'),
-		'editlink' => $editkey ? add_edit_combo('branch') : false
-	), "branch" );
-	return $ret;
-}
-//------------------------------------------------------------------------------------------------
-
-function customer_branches_list_cells($label,$customer_id, $name, $selected_id=null, 
-	$all_option = true, $enabled=true, $submit_on_change=false, $editkey = false)
-{
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo customer_branches_list($customer_id, $name, $selected_id, $all_option, $enabled, 
-		$submit_on_change, $editkey);
-	echo "</td>\n";
+	return ListRenderer::get()->customer_list_row($label, $name, $selected_id, $all_option, $submit_on_change, $show_inactive, $editkey);
 }
 
-function customer_branches_list_row($label, $customer_id, $name, $selected_id=null, 
-	$all_option = true, $enabled=true, $submit_on_change=false, $editkey = false)
+// ------------------------------------------------------------------------------------------------
+function customer_branches_list($customer_id, $name, $selected_id = null, $spec_option = true, $enabled = true, $submit_on_change = false, $editkey = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	customer_branches_list_cells(null, $customer_id, $name, $selected_id, 
-		$all_option, $enabled, $submit_on_change, $editkey);
-	echo "</tr>";
+	return ListRenderer::get()->customer_branches_list($customer_id, $name, $selected_id, $spec_option, $enabled, $submit_on_change, $editkey);
+}
+// ------------------------------------------------------------------------------------------------
+function customer_branches_list_cells($label, $customer_id, $name, $selected_id = null, $all_option = true, $enabled = true, $submit_on_change = false, $editkey = false)
+{
+	return ListRenderer::get()->customer_branches_list_cells($label, $customer_id, $name, $selected_id, $all_option, $enabled, $submit_on_change, $editkey);
 }
 
-//------------------------------------------------------------------------------------------------
-
-function locations_list($name, $selected_id=null, $all_option=false, $submit_on_change=false, $fixed_asset=false)
+function customer_branches_list_row($label, $customer_id, $name, $selected_id = null, $all_option = true, $enabled = true, $submit_on_change = false, $editkey = false)
 {
-
-	$sql = "SELECT loc_code, location_name, inactive FROM ".TB_PREF."locations WHERE fixed_asset=".(int)$fixed_asset;
-
-	return combo_input($name, $selected_id, $sql, 'loc_code', 'location_name',
-		array(
-			'spec_option' => $all_option === true ? _("All Locations") : $all_option,
-			'spec_id' => ALL_TEXT,
-			'select_submit'=> $submit_on_change
-		) );
+	return ListRenderer::get()->customer_branches_list_row($label, $customer_id, $name, $selected_id, $all_option, $enabled, $submit_on_change, $editkey);
 }
 
-function locations_list_cells($label, $name, $selected_id=null, $all_option=false, $submit_on_change=false, $fixed_asset=false)
+// ------------------------------------------------------------------------------------------------
+function locations_list($name, $selected_id = null, $all_option = false, $submit_on_change = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo locations_list($name, $selected_id, $all_option, $submit_on_change, $fixed_asset);
-	echo "</td>\n";
+	return ListRenderer::get()->locations_list($name, $selected_id = null, $all_option, $submit_on_change);
 }
 
-function locations_list_row($label, $name, $selected_id=null, $all_option=false, $submit_on_change=false, $fixed_asset=false)
+function locations_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	locations_list_cells(null, $name, $selected_id, $all_option, $submit_on_change, $fixed_asset);
-	echo "</tr>\n";
+	return ListRenderer::get()->locations_list_cells($label, $name, $selected_id, $all_option, $submit_on_change);
 }
 
-//-----------------------------------------------------------------------------------------------
-
-function currencies_list($name, $selected_id=null, $submit_on_change=false, $exclude_home_curr=false)
+function locations_list_row($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false)
 {
-	$sql = "SELECT curr_abrev, currency, inactive FROM ".TB_PREF."currencies";
-	if ($exclude_home_curr)
-		$sql .= " WHERE curr_abrev!='".get_company_currency()."'";
-
-	// default to the company currency
-	return combo_input($name, $selected_id, $sql, 'curr_abrev', 'currency',
-		array(
-			'select_submit'=> $submit_on_change,
-			'default' => get_company_currency(),
-			'async' => false
-		) );
+	return ListRenderer::get()->locations_list_row($label, $name, $selected_id, $all_option, $submit_on_change);
 }
 
-function currencies_list_cells($label, $name, $selected_id=null, $submit_on_change=false)
+// -----------------------------------------------------------------------------------------------
+function currencies_list($name, $selected_id = null, $submit_on_change = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo currencies_list($name, $selected_id, $submit_on_change);
-	echo "</td>\n";
+	return ListRenderer::get()->currencies_list($name, $selected_id, $submit_on_change);
 }
 
-function currencies_list_row($label, $name, $selected_id=null, $submit_on_change=false)
+function currencies_list_cells($label, $name, $selected_id = null, $submit_on_change = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	currencies_list_cells(null, $name, $selected_id, $submit_on_change);
-	echo "</tr>\n";
+	return ListRenderer::get()->currencies_list_cells($label, $name, $selected_id, $submit_on_change);
 }
 
-//---------------------------------------------------------------------------------------------------
-
-function fiscalyears_list($name, $selected_id=null, $submit_on_change=false)
+function currencies_list_row($label, $name, $selected_id = null, $submit_on_change = false)
 {
+	return ListRenderer::get()->currencies_list_row($label, $name, $selected_id, $submit_on_change);
+}
 
-	$sql = "SELECT * FROM ".TB_PREF."fiscal_year";
-
-	// default to the company current fiscal year
-
-	return combo_input($name, $selected_id, $sql, 'id', '',
-		array(
-			'order' => 'begin',
-			'default' => get_company_pref('f_year'),
-			'format' => '_format_fiscalyears',
-			'select_submit'=> $submit_on_change,
-			'async' => false
-		) );
+// ---------------------------------------------------------------------------------------------------
+function fiscalyears_list($name, $selected_id = null, $submit_on_change = false)
+{
+	return ListRenderer::get()->fiscalyears_list($name, $selected_id, $submit_on_change);
 }
 
 function _format_fiscalyears($row)
 {
-	return sql2date($row[1]) . "&nbsp;-&nbsp;" . sql2date($row[2])
-	. "&nbsp;&nbsp;" . ($row[3] ? _('Closed') : _('Active'));
+	return ListRenderer::get()->_format_fiscalyears($row);
 }
 
-function fiscalyears_list_cells($label, $name, $selected_id=null)
+function fiscalyears_list_cells($label, $name, $selected_id = null)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo fiscalyears_list($name, $selected_id);
-	echo "</td>\n";
+	return ListRenderer::get()->fiscalyears_list_cells($label, $name, $selected_id);
 }
 
-function fiscalyears_list_row($label, $name, $selected_id=null)
+function fiscalyears_list_row($label, $name, $selected_id = null)
 {
-	echo "<tr><td class='label'>$label</td>";
-	fiscalyears_list_cells(null, $name, $selected_id);
-	echo "</tr>\n";
-}
-//------------------------------------------------------------------------------------
-
-function dimensions_list($name, $selected_id=null, $no_option=false, $showname=' ',
-	$submit_on_change=false, $showclosed=false, $showtype=1)
-{
-	$sql = "SELECT id, CONCAT(reference,'  ',name) as ref FROM ".TB_PREF."dimensions";
-
-	$options = array(
-		'order' => 'reference',
-		'spec_option'=>$no_option ? $showname : false,
-		'spec_id' => 0,
-		'select_submit'=> $submit_on_change,
-		'async' => false,
-	);
-
-	if (!$showclosed)
-		$options['where'][] = "closed=0";
-	if($showtype)
-		$options['where'][] = "type_=".db_escape($showtype);
-
-	return combo_input($name, $selected_id, $sql, 'id', 'ref', $options);
+	return ListRenderer::get()->fiscalyears_list_row($label, $name, $selected_id);
 }
 
-function dimensions_list_cells($label, $name, $selected_id=null, $no_option=false, $showname=null,
-	$showclosed=false, $showtype=0, $submit_on_change=false)
+// ------------------------------------------------------------------------------------
+function dimensions_list($name, $selected_id = null, $no_option = false, $showname = ' ', $submit_on_change = false, $showclosed = false, $showtype = 1)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo dimensions_list($name, $selected_id, $no_option, $showname, $submit_on_change, $showclosed, $showtype);
-	echo "</td>\n";
+	return ListRenderer::get()->dimensions_list($name, $selected_id, $no_option, $showname, $submit_on_change, $showclosed, $showtype);
 }
 
-function dimensions_list_row($label, $name, $selected_id=null, $no_option=false, $showname=null,
-	$showclosed=false, $showtype=0, $submit_on_change=false)
+function dimensions_list_cells($label, $name, $selected_id = null, $no_option = false, $showname = null, $showclosed = false, $showtype = 0, $submit_on_change = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	dimensions_list_cells(null, $name, $selected_id, $no_option, $showname,
-		$showclosed, $showtype, $submit_on_change);
-	echo "</tr>\n";
+	return ListRenderer::get()->dimensions_list_cells($label, $name, $selected_id, $no_option, $showname, $showclosed, $showtype, $submit_on_change);
 }
 
-//---------------------------------------------------------------------------------------------------
-
-function stock_items_list($name, $selected_id=null, $all_option=false, 
-	$submit_on_change=false, $opts=array(), $editkey = false, $type = "stock")
+function dimensions_list_row($label, $name, $selected_id = null, $no_option = false, $showname = null, $showclosed = false, $showtype = 0, $submit_on_change = false)
 {
-	$sql = "SELECT stock_id, s.description, c.description, s.inactive, s.editable
-			FROM ".TB_PREF."stock_master s,".TB_PREF."stock_category c WHERE s.category_id=c.category_id";
+	return ListRenderer::get()->dimensions_list_row($label, $name, $selected_id, $no_option, $showname, $showclosed, $showtype, $submit_on_change);
+}
 
-	if (isset($opts['fixed_asset']) && $opts['fixed_asset'])
-		$sql .= " AND mb_flag='F'";
-	else
-		$sql .= " AND mb_flag!='F'";
-
-	if ($editkey)
-		set_editor('item', $name, $editkey);
-
-	$ret = combo_input($name, $selected_id, $sql, 'stock_id', 's.description',
-		array_merge(
-		  array(
-			'format' => '_format_stock_items',
-			'spec_option' => $all_option===true ?  _("All Items") : $all_option,
-			'spec_id' => ALL_TEXT,
-			'search_box' => true,
-			'search' => array("stock_id", "c.description","s.description"),
-			'search_submit' => get_company_pref('no_item_list')!=0 && (!isset($opts['fixed_asset']) || !$opts['fixed_asset']),
-			'size'=>10,
-			'select_submit'=> $submit_on_change,
-			'category' => 2,
-			'order' => array('c.description','stock_id'),
-			'editlink' => $editkey ? add_edit_combo('item') : false,
-			'editable' => false,
-			'max' => 255
-		  ), $opts), $type );
-	return $ret;
+// ---------------------------------------------------------------------------------------------------
+function stock_items_list($name, $selected_id = null, $all_option = false, $submit_on_change = false, $opts = array(), $editkey = false)
+{
+	return ListRenderer::get()->stock_items_list($name, $selected_id, $all_option, $submit_on_change, $opts, $editkey);
 }
 
 function _format_stock_items($row)
 {
-	return (user_show_codes() ?  ($row[0] . "&nbsp;-&nbsp;") : "") . $row[1];
+	return ListRenderer::get()->_format_stock_items($row);
 }
 
-function stock_items_list_cells($label, $name, $selected_id=null, $all_option=false, 
-	$submit_on_change=false, $all=false, $editkey = false, $opts= array())
+function stock_items_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $all = false, $editkey = false)
 {
-	if (isset($opts['fixed_asset']) && $opts['fixed_asset'])
-		$editor_item = 'fa_item';
-	else
-		$editor_item = 'item';
-
-// 	if ($editkey) ??
-//		set_editor($editor_item, $name, $editkey);
-
-	if ($label != null)
-		echo "<td>$label</td>\n";
-
-// ??
-//  $opts = array_merge($options, array('cells'=>true, 'show_inactive'=>$all, 'new_icon' => $editkey ? 'item' : false));
-//
-//	echo stock_items_list($name, $selected_id, $all_option, $submit_on_change, $opts);
-
-	echo stock_items_list($name, $selected_id, $all_option, $submit_on_change,
-		array_merge(array('cells'=>true, 'show_inactive'=>$all), $opts), $editkey);
-
+	return ListRenderer::get()->stock_items_list_cells($label, $name, $selected_id, $all_option, $submit_on_change, $all, $editkey);
 }
+
 /*
-function stock_items_list_row($label, $name, $selected_id=null, $all_option=false, $submit_on_change=false)
-{
-	echo "<tr>\n";
-	stock_items_list_cells($label, $name, $selected_id, $all_option, $submit_on_change);
-	echo "</tr>\n";
-}
-*/
-//---------------------------------------------------------------------------------------------------
+ * function stock_items_list_row($label, $name, $selected_id=null, $all_option=false, $submit_on_change=false) {
+ * ListRenderer::get()->stock_items_list_row($label, $name, $selected_id, $all_option, $submit_on_change); }
+ */
+// ---------------------------------------------------------------------------------------------------
 //
 // Select item via foreign code.
 //
-function sales_items_list($name, $selected_id=null, $all_option=false, 
-	$submit_on_change=false, $type='', $opts=array())
+function sales_items_list($name, $selected_id = null, $all_option = false, $submit_on_change = false, $type = '', $opts = array())
 {
-	// all sales codes
-	$sql = "SELECT i.item_code, i.description, c.description, count(*)>1 as kit,
-			 i.inactive, if(count(*)>1, '0', s.editable) as editable
-			FROM
-			".TB_PREF."stock_master s,
-			".TB_PREF."item_codes i
-			LEFT JOIN
-			".TB_PREF."stock_category c
-			ON i.category_id=c.category_id
-			WHERE i.stock_id=s.stock_id
-      AND mb_flag != 'F'";
-
-	
-	if ($type == 'local')	{ // exclude foreign codes
-		$sql .=	" AND !i.is_foreign"; 
-	} elseif ($type == 'kits') { // sales kits
-		$sql .=	" AND !i.is_foreign AND i.item_code!=i.stock_id";
-	}
-	$sql .= " AND !i.inactive AND !s.inactive AND !s.no_sale";
-	$sql .= " GROUP BY i.item_code";
-
-	return combo_input($name, $selected_id, $sql, 'i.item_code', 'c.description',
-		array_merge(
-		  array(
-			'format' => '_format_stock_items',
-			'spec_option' => $all_option===true ?  _("All Items") : $all_option,
-			'spec_id' => ALL_TEXT,
-			'search_box' => true,
-			'search' => array("i.item_code", "c.description", "i.description"),
-			'search_submit' => get_company_pref('no_item_list')!=0,
-			'size'=>15,
-			'select_submit'=> $submit_on_change,
-			'category' => 2,
-			'order' => array('c.description','i.item_code'),
-			'editable' => 30,
-			'max' => 255
-		  ), $opts), $type == 'kits' ? $type : "stock_sales" );
+	return ListRenderer::get()->sales_items_list($name, $selected_id, $all_option, $submit_on_change, $type, $opts);
 }
 
-function sales_items_list_cells($label, $name, $selected_id=null, $all_option=false, $submit_on_change=false, $editkey=false)
+function sales_items_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $editkey = false)
 {
-	if ($editkey)
-		set_editor('item', $name, $editkey);
-
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo sales_items_list($name, $selected_id, $all_option, $submit_on_change,
-		'', array('cells'=>true));
+	return ListRenderer::get()->sales_items_list_cells($label, $name, $selected_id, $all_option, $submit_on_change, $editkey);
 }
 
-function sales_kits_list($name, $selected_id=null, $all_option=false, $submit_on_change=false)
+function sales_kits_list($name, $selected_id = null, $all_option = false, $submit_on_change = false)
 {
-	return sales_items_list($name, $selected_id, $all_option, $submit_on_change,
-		'kits', array('cells'=>false, 'editable' => false));
+	return ListRenderer::get()->sales_kits_list($name, $selected_id, $all_option, $submit_on_change);
 }
 
-function sales_local_items_list_row($label, $name, $selected_id=null, $all_option=false, $submit_on_change=false)
+function sales_local_items_list_row($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false)
 {
-	echo "<tr>";
-	if ($label != null)
-		echo "<td class='label'>$label</td>\n";
-	echo "<td>";
-	echo sales_items_list($name, $selected_id, $all_option, $submit_on_change,
-		'local', array('cells'=>false, 'editable' => false));
-	echo "</td></tr>";
-}
-//------------------------------------------------------------------------------------
-
-function stock_manufactured_items_list($name, $selected_id=null,
-	$all_option=false, $submit_on_change=false)
-{
-	return stock_items_list($name, $selected_id, $all_option, $submit_on_change,
-		array('where'=>array("mb_flag= 'M'")), false, "stock_manufactured");
+	return ListRenderer::get()->sales_local_items_list_row($label, $name, $selected_id, $all_option, $submit_on_change);
 }
 
-function stock_manufactured_items_list_cells($label, $name, $selected_id=null,
-				$all_option=false, $submit_on_change=false)
+// ------------------------------------------------------------------------------------
+function stock_manufactured_items_list($name, $selected_id = null, $all_option = false, $submit_on_change = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo stock_manufactured_items_list($name, $selected_id, $all_option, $submit_on_change);
-	echo "</td>\n";
+	return ListRenderer::get()->stock_manufactured_items_list($name, $selected_id, $all_option, $submit_on_change);
 }
 
-function stock_manufactured_items_list_row($label, $name, $selected_id=null,
-		$all_option=false, $submit_on_change=false)
+function stock_manufactured_items_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	stock_manufactured_items_list_cells(null, $name, $selected_id, $all_option, $submit_on_change);
-	echo "</tr>\n";
-}
-//------------------------------------------------------------------------------------
-
-function stock_component_items_list($name, $parent_stock_id, $selected_id=null,
-	$all_option=false, $submit_on_change=false, $editkey = false)
-{
-	$parent = db_escape($parent_stock_id);
-	return stock_items_list($name, $selected_id, $all_option, $submit_on_change,
-		array('where'=>array("stock_id != $parent"), 'parent'=> $parent_stock_id), $editkey, "component");
+	return ListRenderer::get()->stock_manufactured_items_list_cells($label, $name, $selected_id, $all_option, $submit_on_change);
 }
 
-
-function stock_component_items_list_cells($label, $name, $parent_stock_id, 
-	$selected_id=null, $all_option=false, $submit_on_change=false, $editkey = false)
+function stock_manufactured_items_list_row($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	$parent = db_escape($parent_stock_id);
-	echo stock_items_list($name, $selected_id, $all_option, $submit_on_change,
-		array('where'=>array("stock_id != '$parent_stock_id'"), 'cells'=>true, 'parent'=> $parent_stock_id), $editkey, "component");
-}
-//------------------------------------------------------------------------------------
-
-function stock_costable_items_list($name, $selected_id=null,
-	$all_option=false, $submit_on_change=false)
-{
-	return stock_items_list($name, $selected_id, $all_option, $submit_on_change,
-		array('where'=>array("mb_flag!='D'")), false, "stock_costable");
+	return ListRenderer::get()->stock_manufactured_items_list_row($label, $name, $selected_id, $all_option, $submit_on_change);
 }
 
-function stock_costable_items_list_cells($label, $name, $selected_id=null, 
-	$all_option=false, $submit_on_change=false)
+// ------------------------------------------------------------------------------------
+function stock_component_items_list($name, $parent_stock_id, $selected_id = null, $all_option = false, $submit_on_change = false, $editkey = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo stock_items_list($name, $selected_id, $all_option, $submit_on_change,
-		array('where'=>array("mb_flag!='D'"), 'cells'=>true), false, "stock_costable");
+	return ListRenderer::get()->stock_component_items_list($name, $parent_stock_id, $selected_id, $all_option, $submit_on_change, $editkey);
 }
 
-//------------------------------------------------------------------------------------
-function stock_purchasable_items_list($name, $selected_id=null,	
-	$all_option=false, $submit_on_change=false, $all=false, $editkey=false)
+function stock_component_items_list_cells($label, $name, $parent_stock_id, $selected_id = null, $all_option = false, $submit_on_change = false, $editkey = false)
 {
-	return stock_items_list($name, $selected_id, $all_option, $submit_on_change,
-		array('where'=>array("NOT no_purchase"), 
-			'show_inactive'=>$all), $editkey, "stock_purchased");
+	return ListRenderer::get()->stock_component_items_list_cells($label, $name, $parent_stock_id, $selected_id, $all_option, $submit_on_change, $editkey);
 }
+
+// ------------------------------------------------------------------------------------
+function stock_costable_items_list($name, $selected_id = null, $all_option = false, $submit_on_change = false)
+{
+	return ListRenderer::get()->stock_costable_items_list($name, $selected_id, $all_option, $submit_on_change);
+}
+
+function stock_costable_items_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false)
+{
+	return ListRenderer::get()->stock_costable_items_list_cells($label, $name, $selected_id, $all_option, $submit_on_change);
+}
+
+// ------------------------------------------------------------------------------------
+function stock_purchasable_items_list($name, $selected_id = null, $all_option = false, $submit_on_change = false, $all = false, $editkey = false)
+{
+	return ListRenderer::get()->stock_purchasable_items_list($name, $selected_id, $all_option, $submit_on_change, $all, $editkey);
+}
+
 //
-//	This helper is used in PO/GRN/PI entry and supports editable descriptions.
+// This helper is used in PO/GRN/PI entry and supports editable descriptions.
 //
-function stock_purchasable_items_list_cells($label, $name, $selected_id=null,
-			$all_option=false, $submit_on_change=false, $editkey=false)
+function stock_purchasable_items_list_cells($label, $name, $selected_id = null, $all_option = false, $submit_on_change = false, $editkey = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo stock_items_list($name, $selected_id, $all_option, $submit_on_change,
-		array('where'=>array("NOT no_purchase"), 
-			 'editable' => 30,
-			 'cells'=>true), $editkey);
+	return ListRenderer::get()->stock_purchasable_items_list_cells($label, $name, $selected_id, $all_option, $submit_on_change, $editkey);
 }
 
-//------------------------------------------------------------------------------------
-
-function stock_item_types_list_row($label, $name, $selected_id=null, $enabled=true)
+/*
+ * function stock_purchasable_items_list_row($label, $name, $selected_id=null, $all_option=false,
+ * $submit_on_change=false, $editkey=false) { ListRenderer::get()->stock_purchasable_items_list_row($label, $name,
+ * $selected_id, $all_option, $submit_on_change, $editkey); }
+ */
+// ------------------------------------------------------------------------------------
+function stock_item_types_list_row($label, $name, $selected_id = null, $enabled = true)
 {
-	global $stock_types;
-
-	echo "<tr>";
-	if ($label != null)
-		echo "<td class='label'>$label</td>\n";
-	echo "<td>";
-
-	echo array_selector($name, $selected_id, $stock_types, 
-		array( 
-			'select_submit'=> true, 
-			'disabled' => !$enabled) );
-	echo "</td></tr>\n";
+	return ListRenderer::get()->stock_item_types_list_row($label, $name, $selected_id, $enabled);
 }
 
-function stock_units_list_row($label, $name, $value=null, $enabled=true)
+function stock_units_list_row($label, $name, $value = null, $enabled = true)
 {
-	$result = get_all_item_units();
-	echo "<tr>";
-	if ($label != null)
-		echo "<td class='label'>$label</td>\n";
-	echo "<td>";
-
-	while($unit = db_fetch($result))
-		$units[$unit['abbr']] = $unit['name'];
-
-	echo array_selector($name, $value, $units, array( 'disabled' => !$enabled) );
-
-	echo "</td></tr>\n";
+	return ListRenderer::get()->stock_units_list_row($label, $name, $value, $enabled);
 }
 
-//------------------------------------------------------------------------------------
-
-function stock_purchasable_fa_list_cells($label, $name, $selected_id=null, $all_option=false,
-	$submit_on_change=false, $all=false, $editkey = false, $exclude_items = array())
+// ------------------------------------------------------------------------------------
+function tax_types_list($name, $selected_id = null, $none_option = false, $submit_on_change = false)
 {
-	// Check if a fixed asset has been bought.
-	$where_opts[] = "stock_id NOT IN
-    	( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE type=".ST_SUPPRECEIVE." AND qty!=0 )";
-
-	// exclude items currently on the order.
-  	foreach($exclude_items as $item) {
-    	$where_opts[] = "stock_id != ".db_escape($item->stock_id);
-  	}
-  	$where_opts[] = "mb_flag='F'";
-
-	echo stock_items_list_cells($label, $name, $selected_id, $all_option, $submit_on_change, $all, $editkey, 
-    array('fixed_asset' => true, 'where' => $where_opts));
+	return ListRenderer::get()->tax_types_list($name, $selected_id, $none_option, $submit_on_change);
 }
 
-function stock_disposable_fa_list($name, $selected_id=null,
-	$all_option=false, $submit_on_change=false)
+function tax_types_list_cells($label, $name, $selected_id = null, $none_option = false, $submit_on_change = false)
 {
-	// Check if a fixed asset has been bought....
-	$where_opts[] = "stock_id IN
-    	( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE type=".ST_SUPPRECEIVE." AND qty!=0 )";
-	// ...but has not been disposed or sold already.
-  	$where_opts[] = "stock_id NOT IN
-		( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE (type=".ST_CUSTDELIVERY." OR type=".ST_INVADJUST.") AND qty!=0 )";
-
-	$where_opts[] = "mb_flag='F'";
-
-	echo stock_items_list($name, $selected_id, $all_option, $submit_on_change,
-    array('fixed_asset' => true, 'where' => $where_opts));
+	return ListRenderer::get()->tax_types_list_cells($label, $name, $selected_id, $none_option, $submit_on_change);
 }
 
-function stock_disposable_fa_list_cells($label, $name, $selected_id=null,
-	$all_option=false, $submit_on_change=false, $exclude_items = array())
+function tax_types_list_row($label, $name, $selected_id = null, $none_option = false, $submit_on_change = false)
 {
-	// Check if a fixed asset has been bought....
-	$where_opts[] = "stock_id IN
-    	( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE type=".ST_SUPPRECEIVE." AND qty!=0 )";
-	// ...but has not been disposed or sold already.
-	$where_opts[] = "stock_id NOT IN
-    	( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE (type=".ST_CUSTDELIVERY." OR type=".ST_INVADJUST.") AND qty!=0 )";
-
-	$where_opts[] = "mb_flag='F'";
-
-	foreach($exclude_items as $item) {
-    	$where_opts[] = "stock_id != ".db_escape($item->stock_id);
-	}
-
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo stock_items_list($name, $selected_id, $all_option, $submit_on_change, 
-    array('fixed_asset' => true, 'cells'=>true, 'where' => $where_opts));
+	return ListRenderer::get()->tax_types_list_row($label, $name, $selected_id, $none_option, $submit_on_change);
 }
 
-function stock_depreciable_fa_list_cells($label, $name, $selected_id=null,
-	$all_option=false, $submit_on_change=false)
+// ------------------------------------------------------------------------------------
+function tax_groups_list($name, $selected_id = null, $none_option = false, $submit_on_change = false)
 {
-
-	// Check if a fixed asset has been bought....
-	$where_opts[] = "stock_id IN
-    	( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE type=".ST_SUPPRECEIVE." AND qty!=0 )";
-	// ...but has not been disposed or sold already.
-	$where_opts[] = "stock_id NOT IN
-    	( SELECT stock_id FROM ".TB_PREF."stock_moves WHERE (type=".ST_CUSTDELIVERY." OR type=".ST_INVADJUST.") AND qty!=0 )";
-
-	$year = get_current_fiscalyear();
-	$y = date('Y', strtotime($year['end']));
-
-	// check if current fiscal year
-	$where_opts[] = "depreciation_date < '".$y."-12-01'";
-	$where_opts[] = "depreciation_date >= '".($y-1)."-12-01'";
-
-	$where_opts[] = "material_cost > 0";
-	$where_opts[] = "mb_flag='F'";
-
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo stock_items_list($name, $selected_id, $all_option, $submit_on_change,
-		 array('fixed_asset' => true, 'where' => $where_opts, 'cells'=>true));
+	return ListRenderer::get()->tax_groups_list($name, $selected_id, $none_option, $submit_on_change);
 }
 
-//------------------------------------------------------------------------------------
-
-function tax_types_list($name, $selected_id=null, $none_option=false, $submit_on_change=false)
+function tax_groups_list_cells($label, $name, $selected_id = null, $none_option = false, $submit_on_change = false)
 {
-	$sql = "SELECT id, CONCAT(name, ' (',rate,'%)') as name FROM ".TB_PREF."tax_types";
-
-	return combo_input($name, $selected_id, $sql, 'id', 'name',
-		array(
-			'spec_option' => $none_option,
-			'spec_id' => ALL_NUMERIC,
-			'select_submit'=> $submit_on_change,
-			'async' => false,
-		) );
+	return ListRenderer::get()->tax_groups_list_cells($label, $name, $selected_id, $none_option, $submit_on_change);
 }
 
-function tax_types_list_cells($label, $name, $selected_id=null, $none_option=false,
-	$submit_on_change=false)
+function tax_groups_list_row($label, $name, $selected_id = null, $none_option = false, $submit_on_change = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo tax_types_list($name, $selected_id, $none_option, $submit_on_change);
-	echo "</td>\n";
+	return ListRenderer::get()->tax_groups_list_row($label, $name, $selected_id, $none_option, $submit_on_change);
 }
 
-function tax_types_list_row($label, $name, $selected_id=null, $none_option=false,
-	$submit_on_change=false)
+// ------------------------------------------------------------------------------------
+function item_tax_types_list($name, $selected_id = null)
 {
-	echo "<tr><td class='label'>$label</td>";
-	tax_types_list_cells(null, $name, $selected_id, $none_option, $submit_on_change);
-	echo "</tr>\n";
+	return ListRenderer::get()->item_tax_types_list($name, $selected_id);
 }
 
-//------------------------------------------------------------------------------------
-
-function tax_groups_list($name, $selected_id=null,
-	$none_option=false, $submit_on_change=false)
+function item_tax_types_list_cells($label, $name, $selected_id = null)
 {
-	$sql = "SELECT id, name FROM ".TB_PREF."tax_groups";
-
-	return combo_input($name, $selected_id, $sql, 'id', 'name',
-		array(
-			'order' => 'id',
-			'spec_option' => $none_option,
-			'spec_id' => ALL_NUMERIC,
-			'select_submit'=> $submit_on_change,
-			'async' => false,
-		) );
+	return ListRenderer::get()->item_tax_types_list_cells($label, $name, $selected_id);
 }
 
-function tax_groups_list_cells($label, $name, $selected_id=null, $none_option=false, $submit_on_change=false)
+function item_tax_types_list_row($label, $name, $selected_id = null)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo tax_groups_list($name, $selected_id, $none_option, $submit_on_change);
-	echo "</td>\n";
+	return ListRenderer::get()->item_tax_types_list_row($label, $name, $selected_id);
 }
 
-function tax_groups_list_row($label, $name, $selected_id=null, $none_option=false, $submit_on_change=false)
+// ------------------------------------------------------------------------------------
+function shippers_list($name, $selected_id = null)
 {
-	echo "<tr><td class='label'>$label</td>";
-	tax_groups_list_cells(null, $name, $selected_id, $none_option, $submit_on_change);
-	echo "</tr>\n";
+	return ListRenderer::get()->shippers_list($name, $selected_id);
 }
 
-//------------------------------------------------------------------------------------
-
-function item_tax_types_list($name, $selected_id=null)
+function shippers_list_cells($label, $name, $selected_id = null)
 {
-	$sql ="SELECT id, name FROM ".TB_PREF."item_tax_types";
-	return combo_input($name, $selected_id, $sql, 'id', 'name', array('order' => 'id') );
+	return ListRenderer::get()->shippers_list_cells($label, $name, $selected_id);
 }
 
-function item_tax_types_list_cells($label, $name, $selected_id=null)
+function shippers_list_row($label, $name, $selected_id = null)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo item_tax_types_list($name, $selected_id);
-	echo "</td>\n";
+	return ListRenderer::get()->shippers_list_row($label, $name, $selected_id);
 }
 
-function item_tax_types_list_row($label, $name, $selected_id=null)
+// -------------------------------------------------------------------------------------
+function sales_persons_list($name, $selected_id = null, $spec_opt = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	item_tax_types_list_cells(null, $name, $selected_id);
-	echo "</tr>\n";
+	return ListRenderer::get()->sales_persons_list($name, $selected_id, $spec_opt);
 }
 
-//------------------------------------------------------------------------------------
-
-function shippers_list($name, $selected_id=null)
+function sales_persons_list_cells($label, $name, $selected_id = null, $spec_opt = false)
 {
-	$sql = "SELECT shipper_id, shipper_name, inactive FROM ".TB_PREF."shippers";
-	return combo_input($name, $selected_id, $sql, 'shipper_id', 'shipper_name', 
-		array('order'=>array('shipper_name')));
+	return ListRenderer::get()->sales_persons_list_cells($label, $name, $selected_id, $spec_opt);
 }
 
-function shippers_list_cells($label, $name, $selected_id=null)
+function sales_persons_list_row($label, $name, $selected_id = null, $spec_opt = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo shippers_list($name, $selected_id);
-	echo "</td>\n";
+	return ListRenderer::get()->sales_persons_list_row($label, $name, $selected_id, $spec_opt);
 }
 
-function shippers_list_row($label, $name, $selected_id=null)
+// ------------------------------------------------------------------------------------
+function sales_areas_list($name, $selected_id = null)
 {
-	echo "<tr><td class='label'>$label</td>";
-	shippers_list_cells(null, $name, $selected_id);
-	echo "</tr>\n";
+	return ListRenderer::get()->sales_areas_list($name, $selected_id);
 }
 
-//-------------------------------------------------------------------------------------
-
-function sales_persons_list($name, $selected_id=null, $spec_opt=false)
+function sales_areas_list_cells($label, $name, $selected_id = null)
 {
-	$sql = "SELECT salesman_code, salesman_name, inactive FROM ".TB_PREF."salesman";
-	return combo_input($name, $selected_id, $sql, 'salesman_code', 'salesman_name', 
-		array('order'=>array('salesman_name'),
-			'spec_option' => $spec_opt,
-			'spec_id' => ALL_NUMERIC));
+	return ListRenderer::get()->sales_areas_list_cells($label, $name, $selected_id);
 }
 
-function sales_persons_list_cells($label, $name, $selected_id=null, $spec_opt=false)
+function sales_areas_list_row($label, $name, $selected_id = null)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>\n";
-	echo sales_persons_list($name, $selected_id, $spec_opt);
-	echo "</td>\n";
+	return ListRenderer::get()->sales_areas_list_row($label, $name, $selected_id);
 }
 
-function sales_persons_list_row($label, $name, $selected_id=null, $spec_opt=false)
+// ------------------------------------------------------------------------------------
+function sales_groups_list($name, $selected_id = null, $special_option = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	sales_persons_list_cells(null, $name, $selected_id, $spec_opt);
-	echo "</tr>\n";
+	return ListRenderer::get()->sales_groups_list($name, $selected_id, $special_option);
 }
 
-//------------------------------------------------------------------------------------
-
-function sales_areas_list($name, $selected_id=null)
+function sales_groups_list_cells($label, $name, $selected_id = null, $special_option = false)
 {
-	$sql = "SELECT area_code, description, inactive FROM ".TB_PREF."areas";
-	return combo_input($name, $selected_id, $sql, 'area_code', 'description', array());
+	return ListRenderer::get()->sales_groups_list_cells($label, $name, $selected_id, $special_option);
 }
 
-function sales_areas_list_cells($label, $name, $selected_id=null)
+function sales_groups_list_row($label, $name, $selected_id = null, $special_option = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo sales_areas_list($name, $selected_id);
-	echo "</td>\n";
+	return ListRenderer::get()->sales_groups_list_row($label, $name, $selected_id, $special_option);
 }
 
-function sales_areas_list_row($label, $name, $selected_id=null)
-{
-	echo "<tr><td class='label'>$label</td>";
-	sales_areas_list_cells(null, $name, $selected_id);
-	echo "</tr>\n";
-}
-
-//------------------------------------------------------------------------------------
-
-function sales_groups_list($name, $selected_id=null, $special_option=false)
-{
-	$sql = "SELECT id, description, inactive FROM ".TB_PREF."groups";
-	return combo_input($name, $selected_id, $sql, 'id', 'description', array(
-		'spec_option' => $special_option===true ? ' ' : $special_option,
-		'order' => 'description', 'spec_id' => 0,
-	));
-}
-
-function sales_groups_list_cells($label, $name, $selected_id=null, $special_option=false)
-{
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo sales_groups_list($name, $selected_id, $special_option);
-	echo "</td>\n";
-}
-
-function sales_groups_list_row($label, $name, $selected_id=null, $special_option=false)
-{
-	echo "<tr><td class='label'>$label</td>";
-	sales_groups_list_cells(null, $name, $selected_id, $special_option);
-	echo "</tr>\n";
-}
-
-//------------------------------------------------------------------------------------
-
+// ------------------------------------------------------------------------------------
 function _format_template_items($row)
 {
-	return ($row[0] . "&nbsp;- &nbsp;" . _("Amount") . "&nbsp;".$row[1]);
+	return ListRenderer::get()->_format_template_items($row);
 }
 
-function templates_list($name, $selected_id=null, $special_option=false)
+function templates_list($name, $selected_id = null, $special_option = false)
 {
-	$sql = "SELECT sorder.order_no,	Sum(line.unit_price*line.quantity*(1-line.discount_percent)) AS OrderValue
-		FROM ".TB_PREF."sales_orders as sorder, ".TB_PREF."sales_order_details as line
-		WHERE sorder.order_no = line.order_no AND sorder.type = 1 GROUP BY line.order_no";
-	return combo_input($name, $selected_id, $sql, 'order_no', 'OrderValue', array(
-		'format' => '_format_template_items',
-		'spec_option' => $special_option===true ? ' ' : $special_option,
-		'order' => 'order_no', 'spec_id' => 0,
-	));
+	return ListRenderer::get()->templates_list($name, $selected_id, $special_option);
 }
 
-function templates_list_cells($label, $name, $selected_id=null, $special_option=false)
+function templates_list_cells($label, $name, $selected_id = null, $special_option = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo templates_list($name, $selected_id, $special_option);
-	echo "</td>\n";
+	return ListRenderer::get()->templates_list_cells($label, $name, $selected_id, $special_option);
 }
 
-function templates_list_row($label, $name, $selected_id=null, $special_option=false)
+function templates_list_row($label, $name, $selected_id = null, $special_option = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	templates_list_cells(null, $name, $selected_id, $special_option);
-	echo "</tr>\n";
+	return ListRenderer::get()->templates_list_row($label, $name, $selected_id, $special_option);
 }
 
-//------------------------------------------------------------------------------------
-
-function workorders_list($name, $selected_id=null)
+// ------------------------------------------------------------------------------------
+function workorders_list($name, $selected_id = null)
 {
-	$sql = "SELECT id, wo_ref FROM ".TB_PREF."workorders WHERE closed=0";
-	return combo_input($name, $selected_id, $sql, 'id', 'wo_ref', array());
+	return ListRenderer::get()->workorders_list($name, $selected_id);
 }
 
-function workorders_list_cells($label, $name, $selected_id=null)
+function workorders_list_cells($label, $name, $selected_id = null)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo workorders_list($name, $selected_id);
-	echo "</td>\n";
+	return ListRenderer::get()->workorders_list_cells($label, $name, $selected_id);
 }
 
-function workorders_list_row($label, $name, $selected_id=null)
+function workorders_list_row($label, $name, $selected_id = null)
 {
-	echo "<tr><td class='label'>$label</td>";
-	workorders_list_cells(null, $name, $selected_id);
-	echo "</tr>\n";
+	return ListRenderer::get()->workorders_list_row($label, $name, $selected_id);
 }
 
-//------------------------------------------------------------------------------------
-
-function payment_terms_list($name, $selected_id=null)
+// ------------------------------------------------------------------------------------
+function payment_terms_list($name, $selected_id = null)
 {
-	$sql = "SELECT terms_indicator, terms, inactive FROM ".TB_PREF."payment_terms";
-	return combo_input($name, $selected_id, $sql, 'terms_indicator', 'terms', array());
+	return ListRenderer::get()->payment_terms_list($name, $selected_id);
 }
 
-function payment_terms_list_cells($label, $name, $selected_id=null)
+function payment_terms_list_cells($label, $name, $selected_id = null)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo payment_terms_list($name, $selected_id);
-	echo "</td>\n";
+	return ListRenderer::get()->payment_terms_list_cells($label, $name, $selected_id);
 }
 
-function payment_terms_list_row($label, $name, $selected_id=null)
+function payment_terms_list_row($label, $name, $selected_id = null)
 {
-	echo "<tr><td class='label'>$label</td>";
-	payment_terms_list_cells(null, $name, $selected_id);
-	echo "</tr>\n";
+	return ListRenderer::get()->payment_terms_list_row($label, $name, $selected_id);
 }
 
-//------------------------------------------------------------------------------------
-
-function credit_status_list($name, $selected_id=null)
+// ------------------------------------------------------------------------------------
+function credit_status_list($name, $selected_id = null)
 {
-	$sql ="SELECT id, reason_description, inactive FROM ".TB_PREF."credit_status";
-	return combo_input($name, $selected_id, $sql, 'id', 'reason_description', array());
+	return ListRenderer::get()->credit_status_list($name, $selected_id);
 }
 
-function credit_status_list_cells($label, $name, $selected_id=null)
+function credit_status_list_cells($label, $name, $selected_id = null)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo credit_status_list($name, $selected_id);
-	echo "</td>\n";
+	return ListRenderer::get()->credit_status_list_cells($label, $name, $selected_id);
 }
 
-function credit_status_list_row($label, $name, $selected_id=null)
+function credit_status_list_row($label, $name, $selected_id = null)
 {
-	echo "<tr><td class='label'>$label</td>";
-	credit_status_list_cells(null, $name, $selected_id);
-	echo "</tr>\n";
+	return ListRenderer::get()->credit_status_list_row($label, $name, $selected_id);
 }
 
-//-----------------------------------------------------------------------------------------------
-
-function sales_types_list($name, $selected_id=null, $submit_on_change=false, $special_option=false)
+// -----------------------------------------------------------------------------------------------
+function sales_types_list($name, $selected_id = null, $submit_on_change = false, $special_option = false)
 {
-	$sql = "SELECT id, sales_type, inactive FROM ".TB_PREF."sales_types";
-
-	return combo_input($name, $selected_id, $sql, 'id', 'sales_type',
-	array(
-		'spec_option' => $special_option===true ? _("All Sales Types") : $special_option,
-		'spec_id' => 0,
-		'select_submit'=> $submit_on_change,
-	) );
+	return ListRenderer::get()->sales_types_list($name, $selected_id, $submit_on_change, $special_option);
 }
 
-function sales_types_list_cells($label, $name, $selected_id=null, $submit_on_change=false, $special_option=false)
+function sales_types_list_cells($label, $name, $selected_id = null, $submit_on_change = false, $special_option = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo sales_types_list($name, $selected_id, $submit_on_change, $special_option);
-	echo "</td>\n";
+	return ListRenderer::get()->sales_types_list_cells($label, $name, $selected_id, $submit_on_change, $special_option);
 }
 
-function sales_types_list_row($label, $name, $selected_id=null, $submit_on_change=false, $special_option=false)
+function sales_types_list_row($label, $name, $selected_id = null, $submit_on_change = false, $special_option = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	sales_types_list_cells(null, $name, $selected_id, $submit_on_change, $special_option);
-	echo "</tr>\n";
+	return ListRenderer::get()->sales_types_list_row($label, $name, $selected_id, $submit_on_change, $special_option);
 }
 
-//-----------------------------------------------------------------------------------------------
+// -----------------------------------------------------------------------------------------------
 
 function _format_date($row)
 {
-	return sql2date($row['reconciled']);
+	return ListRenderer::get()->_format_date($row);
 }
 
-function bank_reconciliation_list($account, $name, $selected_id=null, $submit_on_change=false, $special_option=false)
+function bank_reconciliation_list($account, $name, $selected_id = null, $submit_on_change = false, $special_option = false)
 {
-	$sql = "SELECT reconciled, reconciled FROM ".TB_PREF."bank_trans
-		WHERE bank_act=".db_escape($account)." AND reconciled IS NOT NULL
-		GROUP BY reconciled";
-	return combo_input($name, $selected_id, $sql, 'id', 'reconciled',
-		array(
-			'spec_option' => $special_option,
-			'format' => '_format_date',
-			'spec_id' => '',
-			'select_submit'=> $submit_on_change
-		) );
+	return ListRenderer::get()->bank_reconciliation_list($account, $name, $selected_id, $submit_on_change, $special_option);
 }
 
-function bank_reconciliation_list_cells($label,$account, $name, $selected_id=null, $submit_on_change=false, $special_option=false)
+function bank_reconciliation_list_cells($label, $account, $name, $selected_id = null, $submit_on_change = false, $special_option = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo bank_reconciliation_list($account, $name, $selected_id, $submit_on_change, $special_option);
-	echo "</td>\n";
+	return ListRenderer::get()->bank_reconciliation_list_cells($label, $account, $name, $selected_id, $submit_on_change, $special_option);
 }
+
 /*
 function bank_reconciliation_list_row($label, $account, $name, $selected_id=null, $submit_on_change=false, $special_option=false)
 {
@@ -1516,1184 +517,479 @@ function bank_reconciliation_list_row($label, $account, $name, $selected_id=null
 	echo "</tr>\n";
 }
 */
-//-----------------------------------------------------------------------------------------------
-
-function workcenter_list($name, $selected_id=null, $all_option=false)
+// -----------------------------------------------------------------------------------------------
+function workcenter_list($name, $selected_id = null, $all_option = false)
 {
-
-	$sql = "SELECT id, name, inactive FROM ".TB_PREF."workcentres";
-
-	return combo_input($name, $selected_id, $sql, 'id', 'name',
-		array(
-			'spec_option' =>$all_option===true ? _("All Suppliers") : $all_option,
-			'spec_id' => ALL_TEXT,
-		) );
+	return ListRenderer::get()->workcenter_list($name, $selected_id, $all_option);
 }
 
-function workcenter_list_cells($label, $name, $selected_id=null, $all_option=false)
+function workcenter_list_cells($label, $name, $selected_id = null, $all_option = false)
 {
-	default_focus($name);
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo workcenter_list($name, $selected_id, $all_option);
-	echo "</td>\n";
+	return ListRenderer::get()->workcenter_list_cells($label, $name, $selected_id, $all_option);
 }
 
-function workcenter_list_row($label, $name, $selected_id=null, $all_option=false)
+function workcenter_list_row($label, $name, $selected_id = null, $all_option = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	workcenter_list_cells(null, $name, $selected_id, $all_option);
-	echo "</tr>\n";
+	return ListRenderer::get()->workcenter_list_row($label, $name, $selected_id, $all_option);
 }
 
-//-----------------------------------------------------------------------------------------------
-
-function bank_accounts_list($name, $selected_id=null, $submit_on_change=false, $spec_option=false)
+// -----------------------------------------------------------------------------------------------
+function bank_accounts_list($name, $selected_id = null, $submit_on_change = false, $spec_option = false)
 {
-	$sql = "SELECT id, bank_account_name, bank_curr_code, inactive
-		FROM ".TB_PREF."bank_accounts";
-
-	return combo_input($name, $selected_id, $sql, 'id', 'bank_account_name',
-		array(
-			'format' => '_format_add_curr',
-			'select_submit'=> $submit_on_change,
-			'spec_option' => $spec_option,
-			'spec_id' => '',
-			'async' => false
-		) );
+	return ListRenderer::get()->bank_accounts_list($name, $selected_id, $submit_on_change, $spec_option);
 }
 
-function bank_accounts_list_cells($label, $name, $selected_id=null, $submit_on_change=false)
+function bank_accounts_list_cells($label, $name, $selected_id = null, $submit_on_change = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo bank_accounts_list($name, $selected_id, $submit_on_change);
-	echo "</td>\n";
+	return ListRenderer::get()->bank_accounts_list_cells($label, $name, $selected_id, $submit_on_change);
 }
 
-function bank_accounts_list_row($label, $name, $selected_id=null, $submit_on_change=false)
+function bank_accounts_list_row($label, $name, $selected_id = null, $submit_on_change = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	bank_accounts_list_cells(null, $name, $selected_id, $submit_on_change);
-	echo "</tr>\n";
+	return ListRenderer::get()->bank_accounts_list_row($label, $name, $selected_id, $submit_on_change);
 }
-//-----------------------------------------------------------------------------------------------
 
-function cash_accounts_list_row($label, $name, $selected_id=null, $submit_on_change=false, $all_option=false)
+// -----------------------------------------------------------------------------------------------
+function cash_accounts_list_row($label, $name, $selected_id = null, $submit_on_change = false)
 {
-
-	$sql = "SELECT id, bank_account_name, bank_curr_code, inactive
-		FROM ".TB_PREF."bank_accounts
-		WHERE account_type=".BT_CASH;
-
-	if ($label != null)
-		echo "<tr><td class='label'>$label</td>\n";
-	echo "<td>";
-	echo combo_input($name, $selected_id, $sql, 'id', 'bank_account_name',
-		array(
-			'spec_option' => $all_option,
-			'spec_id' => ALL_TEXT,
-			'format' => '_format_add_curr',
-			'select_submit'=> $submit_on_change,
-			'async' => true
-		) );
-	echo "</td></tr>\n";
+	return ListRenderer::get()->cash_accounts_list_row($label, $name, $selected_id, $submit_on_change);
 }
-//-----------------------------------------------------------------------------------------------
 
-function pos_list_row($label, $name, $selected_id=null, $spec_option=false, $submit_on_change=false)
+// -----------------------------------------------------------------------------------------------
+function pos_list_row($label, $name, $selected_id = null, $spec_option = false, $submit_on_change = false)
 {
-	$sql = "SELECT id, pos_name, inactive FROM ".TB_PREF."sales_pos";
-
-	default_focus($name);
-	echo '<tr>';
-	if ($label != null)
-		echo "<td class='label'>$label</td>\n";
-	echo "<td>";
-
-	echo combo_input($name, $selected_id, $sql, 'id', 'pos_name',
-		array(
-			'select_submit'=> $submit_on_change,
-			'async' => true,
-			'spec_option' =>$spec_option,
-			'spec_id' => -1,
-			'order'=> array('pos_name')
-		) );
-	echo "</td></tr>\n";
-
+	return ListRenderer::get()->pos_list_row($label, $name, $selected_id, $spec_option, $submit_on_change);
 }
-//-----------------------------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------------------------
 // Payment type selector for current user.
 //
-function sale_payment_list($name, $category, $selected_id=null, $submit_on_change=true, $prepayments=true)
+function sale_payment_list($name, $category, $selected_id = null, $submit_on_change = true)
 {
-	$sql = "SELECT terms_indicator, terms, inactive FROM ".TB_PREF."payment_terms";
-
-	if ($category == PM_CASH) // only cash
-			$sql .= " WHERE days_before_due=0 AND day_in_following_month=0";
-	elseif ($category == PM_CREDIT) // only delayed payments
-			$sql .= " WHERE days_before_due".($prepayments ? '!=': '>')."0 OR day_in_following_month!=0";
-	elseif (!$prepayments)
-			$sql .= " WHERE days_before_due>=0";
-
-	return combo_input($name, $selected_id, $sql, 'terms_indicator', 'terms',
-		array(
-			'select_submit'=> $submit_on_change,
-			'async' => true
-		) );
-
+	return ListRenderer::get()->sale_payment_list($name, $category, $selected_id, $submit_on_change);
 }
 
-function sale_payment_list_cells($label, $name, $category, $selected_id=null, $submit_on_change=true, $prepayments=true)
+function sale_payment_list_cells($label, $name, $category, $selected_id = null, $submit_on_change = true)
 {
-	if ($label != null)
-		echo "<td class='label'>$label</td>\n";
-	echo "<td>";
-
-	echo sale_payment_list($name, $category, $selected_id, $submit_on_change, $prepayments);
-
-	echo "</td>\n";
-}
-//-----------------------------------------------------------------------------------------------
-
-function class_list($name, $selected_id=null, $submit_on_change=false)
-{
-	$sql = "SELECT cid, class_name FROM ".TB_PREF."chart_class";
-
-	return combo_input($name, $selected_id, $sql, 'cid', 'class_name',
-		array(
-			'select_submit'=> $submit_on_change,
-			'async' => false
-		) );
-
+	return ListRenderer::get()->sale_payment_list_cells($label, $name, $category, $selected_id, $submit_on_change);
 }
 
-function class_list_cells($label, $name, $selected_id=null, $submit_on_change=false)
+// -----------------------------------------------------------------------------------------------
+function class_list($name, $selected_id = null, $submit_on_change = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo class_list($name, $selected_id, $submit_on_change);
-	echo "</td>\n";
+	return ListRenderer::get()->class_list($name, $selected_id, $submit_on_change);
 }
 
-function class_list_row($label, $name, $selected_id=null, $submit_on_change=false)
+function class_list_cells($label, $name, $selected_id = null, $submit_on_change = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	class_list_cells(null, $name, $selected_id, $submit_on_change);
-	echo "</tr>\n";
+	return ListRenderer::get()->class_list_cells($label, $name, $selected_id, $submit_on_change);
 }
 
-//-----------------------------------------------------------------------------------------------
-function stock_categories_list($name, $selected_id=null, $spec_opt=false, $submit_on_change=false, $fixed_asset=false)
+function class_list_row($label, $name, $selected_id = null, $submit_on_change = false)
 {
-	$where_opts = array();
-	if ($fixed_asset)
-		$where_opts[0] = "dflt_mb_flag='F'";
-	else
-		$where_opts[0] = "dflt_mb_flag!='F'";
-
-	$sql = "SELECT category_id, description, inactive FROM ".TB_PREF."stock_category";
-	return combo_input($name, $selected_id, $sql, 'category_id', 'description',
- 		array('order'=>'category_id',
-			'spec_option' => $spec_opt,
-			'spec_id' => -1,
- 			'select_submit'=> $submit_on_change,
- 			'async' => true,
-			'where' => $where_opts,
- 		));
+	return ListRenderer::get()->class_list_row($label, $name, $selected_id, $submit_on_change);
 }
 
-function stock_categories_list_cells($label, $name, $selected_id=null, $spec_opt=false, $submit_on_change=false, $fixed_asset=false)
+// -----------------------------------------------------------------------------------------------
+function stock_categories_list($name, $selected_id = null, $spec_opt = false, $submit_on_change = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo stock_categories_list($name, $selected_id, $spec_opt, $submit_on_change, $fixed_asset);
-	echo "</td>\n";
+	return ListRenderer::get()->stock_categories_list($name, $selected_id, $spec_opt, $submit_on_change);
 }
 
-function stock_categories_list_row($label, $name, $selected_id=null, $spec_opt=false, $submit_on_change=false, $fixed_asset=false)
+function stock_categories_list_cells($label, $name, $selected_id = null, $spec_opt = false, $submit_on_change = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	stock_categories_list_cells(null, $name, $selected_id, $spec_opt, $submit_on_change, $fixed_asset);
-	echo "</tr>\n";
+	return ListRenderer::get()->stock_categories_list_cells($label, $name, $selected_id, $spec_opt, $submit_on_change);
 }
 
-//-----------------------------------------------------------------------------------------------
-function fixed_asset_classes_list($name, $selected_id=null, $spec_opt=false, $submit_on_change=false)
+function stock_categories_list_row($label, $name, $selected_id = null, $spec_opt = false, $submit_on_change = false)
 {
-	$sql = "SELECT c.fa_class_id, CONCAT(c.fa_class_id,' - ',c.description) `desc`, CONCAT(p.fa_class_id,' - ',p.description) `class`, c.inactive FROM "
-		.TB_PREF."stock_fa_class c LEFT JOIN ".TB_PREF."stock_fa_class p ON c.parent_id=p.fa_class_id";
-
-	return combo_input($name, $selected_id, $sql, 'c.fa_class_id', 'desc',
-		array('order'=>'c.fa_class_id',
-			'spec_option' => $spec_opt,
-			'spec_id' => '-1',
- 			'select_submit'=> $submit_on_change,
- 			'async' => true,
-			'search_box' => true,
-			'search' => array("c.fa_class_id"),
-		    'search_submit' => false,
-		    'spec_id' => '',
-		    'size' => 3,
-		    'max' => 3,
-			'category' => 'class',
- 		));
+	return ListRenderer::get()->stock_categories_list_row($label, $name, $selected_id, $spec_opt, $submit_on_change);
 }
 
-function fixed_asset_classes_list_row($label, $name, $selected_id=null, $spec_opt=false, $submit_on_change=false)
+// -----------------------------------------------------------------------------------------------
+function gl_account_types_list($name, $selected_id = null, $all_option = false, $all = true)
 {
-	echo "<tr><td class='label'>$label</td>";
-	echo "<td>";
-	echo fixed_asset_classes_list($name, $selected_id, $spec_opt, $submit_on_change);
-	echo "</td></tr>\n";
+	return ListRenderer::get()->gl_account_types_list($name, $selected_id, $all_option, $all);
 }
 
-//-----------------------------------------------------------------------------------------------
-
-function gl_account_types_list($name, $selected_id=null, $all_option=false, $all=true)
+function gl_account_types_list_cells($label, $name, $selected_id = null, $all_option = false, $all = false)
 {
-
-	$sql = "SELECT id, name FROM ".TB_PREF."chart_types";
-
-	return combo_input($name, $selected_id, $sql, 'id', 'name',
-		array(
-			'format' => '_format_account',
-			'order' => array('class_id', 'id', 'parent'),
-			'spec_option' =>$all_option,
-			'spec_id' => ALL_TEXT
-		) );
+	return ListRenderer::get()->gl_account_types_list_cells($label, $name, $selected_id, $all_option, $all);
 }
 
-function gl_account_types_list_cells($label, $name, $selected_id=null, $all_option=false, $all=false)
+function gl_account_types_list_row($label, $name, $selected_id = null, $all_option = false, $all = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo gl_account_types_list($name, $selected_id, $all_option, $all);
-	echo "</td>\n";
+	return ListRenderer::get()->gl_account_types_list_row($label, $name, $selected_id, $all_option, $all);
 }
 
-function gl_account_types_list_row($label, $name, $selected_id=null, $all_option=false,	$all=false)
+// -----------------------------------------------------------------------------------------------
+function gl_all_accounts_list($name, $selected_id = null, $skip_bank_accounts = false, $cells = false, $all_option = false, $submit_on_change = false, $all = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	gl_account_types_list_cells(null, $name, $selected_id, $all_option,
-		$all);
-	echo "</tr>\n";
-}
-
-//-----------------------------------------------------------------------------------------------
-function gl_all_accounts_list($name, $selected_id=null, $skip_bank_accounts=false,
-	$cells=false, $all_option=false, $submit_on_change=false, $all=false)
-{
-	if ($skip_bank_accounts)
-		$sql = "SELECT chart.account_code, chart.account_name, type.name, chart.inactive, type.id
-			FROM (".TB_PREF."chart_master chart,".TB_PREF."chart_types type) "
-			."LEFT JOIN ".TB_PREF."bank_accounts acc "
-			."ON chart.account_code=acc.account_code
-				WHERE acc.account_code  IS NULL
-			AND chart.account_type=type.id";
-	else
-		$sql = "SELECT chart.account_code, chart.account_name, type.name, chart.inactive, type.id
-			FROM ".TB_PREF."chart_master chart,".TB_PREF."chart_types type
-			WHERE chart.account_type=type.id";
-
-	return combo_input($name, $selected_id, $sql, 'chart.account_code', 'chart.account_name',
-		array(
-			'format' => '_format_account',
-			'spec_option' => $all_option===true ?  _("Use Item Sales Accounts") : $all_option,
-			'spec_id' => '',
-			'type' => 2,
-			'order' => array('type.class_id','type.id','account_code'),
-			'search_box' => $cells,
-			'search_submit' => false,
-			'size' => 12,
-			'max' => 10,
-			'cells' => true,
-			'select_submit'=> $submit_on_change,
-			'async' => false,
-			'category' => 2,
-			'show_inactive' => $all
-		), "account" );
+	return ListRenderer::get()->gl_all_accounts_list($name, $selected_id, $skip_bank_accounts, $cells, $all_option, $submit_on_change, $all);
 }
 
 function _format_account($row)
 {
-	return $row[0] .  "&nbsp;&nbsp;&nbsp;&nbsp;" . $row[1];
+	return ListRenderer::get()->_format_account($row);
 }
 
-function gl_all_accounts_list_cells($label, $name, $selected_id=null, 
-	$skip_bank_accounts=false, $cells=false, $all_option=false, 
-	$submit_on_change=false, $all=false)
+function gl_all_accounts_list_cells($label, $name, $selected_id = null, $skip_bank_accounts = false, $cells = false, $all_option = false, $submit_on_change = false, $all = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo gl_all_accounts_list($name, $selected_id, 
-		$skip_bank_accounts, $cells, $all_option, $submit_on_change, $all);
-	echo "</td>\n";
+	return ListRenderer::get()->gl_all_accounts_list_cells($label, $name, $selected_id, $skip_bank_accounts, $cells, $all_option, $submit_on_change, $all);
 }
 
-function gl_all_accounts_list_row($label, $name, $selected_id=null, 
-	$skip_bank_accounts=false, $cells=false, $all_option=false)
+function gl_all_accounts_list_row($label, $name, $selected_id = null, $skip_bank_accounts = false, $cells = false, $all_option = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	gl_all_accounts_list_cells(null, $name, $selected_id, 
-		$skip_bank_accounts, $cells, $all_option);
-	echo "</tr>\n";
+	return ListRenderer::get()->gl_all_accounts_list_row($label, $name, $selected_id, $skip_bank_accounts, $cells, $all_option);
 }
 
-function yesno_list($name, $selected_id=null, $name_yes="", $name_no="", $submit_on_change=false)
+function yesno_list($name, $selected_id = null, $name_yes = "", $name_no = "", $submit_on_change = false)
 {
-	$items = array();
-	$items['0'] = strlen($name_no) ? $name_no : _("No");
-	$items['1'] = strlen($name_yes) ? $name_yes : _("Yes");
-
-	return array_selector($name, $selected_id, $items, 
-		array( 
-			'select_submit'=> $submit_on_change,
-			'async' => false ) ); // FIX?
+	return ListRenderer::get()->yesno_list($name, $selected_id, $name_yes, $name_no, $submit_on_change);
 }
 
-function yesno_list_cells($label, $name, $selected_id=null, $name_yes="", $name_no="", $submit_on_change=false)
+function yesno_list_cells($label, $name, $selected_id = null, $name_yes = "", $name_no = "", $submit_on_change = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo yesno_list($name, $selected_id, $name_yes, $name_no, $submit_on_change);
-	echo "</td>\n";
+	return ListRenderer::get()->yesno_list_cells($label, $name, $selected_id, $name_yes, $name_no, $submit_on_change);
 }
 
-function yesno_list_row($label, $name, $selected_id=null, $name_yes="", $name_no="", $submit_on_change=false)
+function yesno_list_row($label, $name, $selected_id = null, $name_yes = "", $name_no = "", $submit_on_change = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	yesno_list_cells(null, $name, $selected_id, $name_yes, $name_no, $submit_on_change);
-	echo "</tr>\n";
+	return ListRenderer::get()->yesno_list_row($label, $name, $selected_id, $name_yes, $name_no, $submit_on_change);
 }
 
-//------------------------------------------------------------------------------------------------
-
-function languages_list($name, $selected_id=null, $all_option=false)
+// ------------------------------------------------------------------------------------------------
+function languages_list($name, $selected_id = null, $all_option = false)
 {
-	global $installed_languages;
-
-	$items = array();
-	if ($all_option)
-		$items[''] = $all_option;
-	foreach ($installed_languages as $lang)
-			$items[$lang['code']] = $lang['name'];
-	return array_selector($name, $selected_id, $items);
+	return ListRenderer::get()->languages_list($name, $selected_id, $all_option);
 }
 
-function languages_list_cells($label, $name, $selected_id=null, $all_option=false)
+function languages_list_cells($label, $name, $selected_id = null, $all_option = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo languages_list($name, $selected_id, $all_option);
-	echo "</td>\n";
+	return ListRenderer::get()->languages_list_cells($label, $name, $selected_id, $all_option);
 }
 
-function languages_list_row($label, $name, $selected_id=null, $all_option=false)
+function languages_list_row($label, $name, $selected_id = null, $all_option = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	languages_list_cells(null, $name, $selected_id, $all_option);
-	echo "</tr>\n";
+	return ListRenderer::get()->languages_list_row($label, $name, $selected_id, $all_option);
 }
 
-//------------------------------------------------------------------------------------------------
-
-function bank_account_types_list($name, $selected_id=null)
+// ------------------------------------------------------------------------------------------------
+function bank_account_types_list($name, $selected_id = null)
 {
-	global $bank_account_types;
-
-	return array_selector($name, $selected_id, $bank_account_types);
+	return ListRenderer::get()->bank_account_types_list($name, $selected_id);
 }
 
-function bank_account_types_list_cells($label, $name, $selected_id=null)
+function bank_account_types_list_cells($label, $name, $selected_id = null)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo bank_account_types_list($name, $selected_id);
-	echo "</td>\n";
+	return ListRenderer::get()->bank_account_types_list_cells($label, $name, $selected_id);
 }
 
-function bank_account_types_list_row($label, $name, $selected_id=null)
+function bank_account_types_list_row($label, $name, $selected_id = null)
 {
-	echo "<tr><td class='label'>$label</td>";
-	bank_account_types_list_cells(null, $name, $selected_id);
-	echo "</tr>\n";
+	return ListRenderer::get()->bank_account_types_list_row($label, $name, $selected_id);
 }
 
-//------------------------------------------------------------------------------------------------
-function payment_person_types_list($name, $selected_id=null, $submit_on_change=false)
+// ------------------------------------------------------------------------------------------------
+function payment_person_types_list($name, $selected_id = null, $submit_on_change = false)
 {
-	global $payment_person_types;
-
-	$items = array();
-	foreach ($payment_person_types as $key=>$type)
-	{
-		if ($key != PT_WORKORDER)
-			$items[$key] = $type;
-	}		
-	return array_selector($name, $selected_id, $items, 
-		array( 'select_submit'=> $submit_on_change ) );
+	return ListRenderer::get()->payment_person_types_list($name, $selected_id, $submit_on_change);
 }
 
-function payment_person_types_list_cells($label, $name, $selected_id=null, $related=null)
+function payment_person_types_list_cells($label, $name, $selected_id = null, $related = null)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo payment_person_types_list($name, $selected_id, $related);
-	echo "</td>\n";
+	return ListRenderer::get()->payment_person_types_list_cells($label, $name, $selected_id, $related);
 }
 
-function payment_person_types_list_row($label, $name, $selected_id=null, $related=null)
+function payment_person_types_list_row($label, $name, $selected_id = null, $related = null)
 {
-	echo "<tr><td class='label'>$label</td>";
-	payment_person_types_list_cells(null, $name, $selected_id, $related);
-	echo "</tr>\n";
+	return ListRenderer::get()->payment_person_types_list_row($label, $name, $selected_id, $related);
 }
 
-//------------------------------------------------------------------------------------------------
-
-function wo_types_list($name, $selected_id=null)
+// ------------------------------------------------------------------------------------------------
+function wo_types_list($name, $selected_id = null)
 {
-	global $wo_types_array;
-	
-	return array_selector($name, $selected_id, $wo_types_array, 
-		array( 'select_submit'=> true, 'async' => true ) );
+	return ListRenderer::get()->wo_types_list($name, $selected_id);
 }
 
-function wo_types_list_row($label, $name, $selected_id=null)
+function wo_types_list_row($label, $name, $selected_id = null)
 {
-	echo "<tr><td class='label'>$label</td><td>\n";
-	echo wo_types_list($name, $selected_id);
-	echo "</td></tr>\n";
+	return ListRenderer::get()->wo_types_list_row($label, $name, $selected_id);
 }
 
-//------------------------------------------------------------------------------------------------
-
-function dateformats_list_row($label, $name, $value=null)
+// ------------------------------------------------------------------------------------------------
+function dateformats_list_row($label, $name, $value = null)
 {
-	global $SysPrefs;
-
-	echo "<tr><td class='label'>$label</td>\n<td>";
-	echo array_selector( $name, $value, $SysPrefs->dateformats );
-	echo "</td></tr>\n";
+	return ListRenderer::get()->dateformats_list_row($label, $name, $value);
 }
 
-function dateseps_list_row($label, $name, $value=null)
+function dateseps_list_row($label, $name, $value = null)
 {
-	global $SysPrefs;
-
-	echo "<tr><td class='label'>$label</td>\n<td>";
-	echo array_selector( $name, $value, $SysPrefs->dateseps );
-	echo "</td></tr>\n";
+	return ListRenderer::get()->dateseps_list_row($label, $name, $value);
 }
 
-function thoseps_list_row($label, $name, $value=null)
+function thoseps_list_row($label, $name, $value = null)
 {
-	global $SysPrefs;
-
-	echo "<tr><td class='label'>$label</td>\n<td>";
-	echo array_selector( $name, $value, $SysPrefs->thoseps );
-	echo "</td></tr>\n";
+	return ListRenderer::get()->thoseps_list_row($label, $name, $value);
 }
 
-function decseps_list_row($label, $name, $value=null)
+function decseps_list_row($label, $name, $value = null)
 {
-	global $SysPrefs;
-
-	echo "<tr><td class='label'>$label</td>\n<td>";
-	echo array_selector( $name, $value, $SysPrefs->decseps );
-	echo "</td></tr>\n";
+	return ListRenderer::get()->decseps_list_row($label, $name, $value);
 }
 
-function themes_list_row($label, $name, $value=null)
+function themes_list_row($label, $name, $value = null)
 {
-	global $path_to_root;
-
-	$path = $path_to_root.'/themes/';
-	$themes = array();
-	$themedir = opendir($path);
-	while(false !== ($fname = readdir($themedir)))
-	{
-		if($fname!='.' && $fname!='..' && $fname!='CVS' && is_dir($path.$fname))
-		{
-			$themes[$fname] =  $fname;
-		}
-	}
-	ksort($themes);
-
-	echo "<tr><td class='label'>$label</td>\n<td>";
-	echo array_selector( $name, $value, $themes );
-	echo "</td></tr>\n";
+	return ListRenderer::get()->themes_list_row($label, $name, $value);
 }
 
-function pagesizes_list_row($label, $name, $value=null)
+function pagesizes_list_row($label, $name, $value = null)
 {
-	global $SysPrefs;
-
-	$items = array();
-	foreach ($SysPrefs->pagesizes as $pz)
-		$items[$pz] = $pz;
-
-	echo "<tr><td class='label'>$label</td>\n<td>";
-	echo array_selector( $name, $value, $items );
-	echo "</td></tr>\n";
+	return ListRenderer::get()->pagesizes_list_row($label, $name, $value);
 }
 
-function systypes_list($name, $value=null, $spec_opt=false, $submit_on_change=false, $exclude=array())
+function systypes_list($name, $value = null, $spec_opt = false, $submit_on_change = false, $exclude = array())
 {
-	global $systypes_array;
-
-	// emove non-voidable transactions if needed
-	$systypes = array_diff_key($systypes_array, array_flip($exclude));
-	return array_selector($name, $value, $systypes, 
-		array( 
-			'spec_option'=> $spec_opt,
-			'spec_id' => ALL_NUMERIC,
-			'select_submit'=> $submit_on_change,
-			'async' => false,
-			)
-	);
+	return ListRenderer::get()->systypes_list($name, $value, $spec_opt, $submit_on_change, $exclude);
 }
 
-function systypes_list_cells($label, $name, $value=null, $submit_on_change=false, $exclude=array())
+function systypes_list_cells($label, $name, $value = null, $submit_on_change = false, $exclude = array())
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo systypes_list($name, $value, false, $submit_on_change, $exclude);
-	echo "</td>\n";
+	return ListRenderer::get()->systypes_list_cells($label, $name, $value, $submit_on_change, $exclude);
 }
 
-function systypes_list_row($label, $name, $value=null, $submit_on_change=false, $exclude=array())
+function systypes_list_row($label, $name, $value = null, $submit_on_change = false, $exclude = array())
 {
-	echo "<tr><td class='label'>$label</td>";
-	systypes_list_cells(null, $name, $value, $submit_on_change, $exclude);
-	echo "</tr>\n";
+	return ListRenderer::get()->systypes_list_row($label, $name, $value, $submit_on_change, $exclude);
 }
 
-function journal_types_list_cells($label, $name, $value=null, $submit_on_change=false)
+function journal_types_list_cells($label, $name, $value = null, $submit_on_change = false)
 {
-	global $systypes_array;
-
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-
-	$items = $systypes_array;
-
-	// exclude quotes, orders and dimensions
-	foreach (array(ST_PURCHORDER, ST_SALESORDER, ST_DIMENSION, ST_SALESQUOTE, ST_LOCTRANSFER) as $excl)
-			unset($items[$excl]);
-	
-	echo array_selector($name, $value, $items, 
-		array( 
-			'spec_option'=> _("All"),
-			'spec_id' => -1,
-			'select_submit'=> $submit_on_change,
-			'async' => false
-			)
-	);
-	echo "</td>\n";
+	return ListRenderer::get()->journal_types_list_cells($label, $name, $value, $submit_on_change);
 }
 
-function cust_allocations_list_cells($label, $name, $selected=null)
+function cust_allocations_list_cells($label, $name, $selected = null)
 {
-
-	if ($label != null)
-		label_cell($label);
-	echo "<td>\n";
-	$allocs = array( 
-		ALL_TEXT=>_("All Types"),
-		'1'=> _("Sales Invoices"),
-		'2'=> _("Overdue Invoices"),
-		'3' => _("Payments"),
-		'4' => _("Credit Notes"),
-		'5' => _("Delivery Notes")
-	);
-	echo array_selector($name, $selected, $allocs);
-	echo "</td>\n";
+	return ListRenderer::get()->cust_allocations_list_cells($label, $name, $selected);
 }
 
-function supp_allocations_list_cell($name, $selected=null)
+function supp_allocations_list_cell($name, $selected = null)
 {
-
-	echo "<td>\n";
-	$allocs = array( 
-		ALL_TEXT=>_("All Types"),
-		'1'=> _("Invoices"),
-		'2'=> _("Overdue Invoices"),
-		'3' => _("Payments"),
-		'4' => _("Credit Notes"),
-		'5' => _("Overdue Credit Notes")
-	);
-	echo array_selector($name, $selected, $allocs);
-	echo "</td>\n";
+	return ListRenderer::get()->supp_allocations_list_cell($name, $selected);
 }
 
-function supp_transactions_list_cell($name, $selected=null)
+function supp_transactions_list_cell($name, $selected = null)
 {
-
-	echo "<td>\n";
-	$allocs = array( 
-		ALL_TEXT=>_("All Types"),
-		'6'=>_("GRNs"),
-		'1'=> _("Invoices"),
-		'2'=> _("Overdue Invoices"),
-		'3' => _("Payments"),
-		'4' => _("Credit Notes"),
-		'5' => _("Overdue Credit Notes")
-	);
-
-	echo array_selector($name, $selected, $allocs);
-	echo "</td>\n";
+	return ListRenderer::get()->supp_transactions_list_cell($name, $selected);
 }
 
-function policy_list_cells($label, $name, $selected=null)
+function policy_list_cells($label, $name, $selected = null)
 {
-	if ($label != null)
-		label_cell($label);
-	echo "<td>\n";
-	echo array_selector($name, $selected, 
-				array( '' => _("Automatically put balance on back order"),
-			 		'CAN' => _("Cancel any quantites not delivered")) );
-	echo "</td>\n";
+	return ListRenderer::get()->policy_list_cells($label, $name, $selected);
 }
 
-function policy_list_row($label, $name, $selected=null)
+function policy_list_row($label, $name, $selected = null)
 {
-	echo "<tr><td class='label'>$label</td>";
-	policy_list_cells(null, $name, $selected);
-	echo "</tr>\n";
+	return ListRenderer::get()->policy_list_row($label, $name, $selected);
 }
 
-function credit_type_list_cells($label, $name, $selected=null, $submit_on_change=false)
+function credit_type_list_cells($label, $name, $selected = null, $submit_on_change = false)
 {
-	if ($label != null)
-		label_cell($label);
-	echo "<td>\n";
-	echo array_selector($name, $selected, 
-			array( 'Return' => _("Items Returned to Inventory Location"),
-		 		'WriteOff' => _("Items Written Off")),
-			array( 'select_submit'=> $submit_on_change ) );
-	echo "</td>\n";
+	return ListRenderer::get()->credit_type_list_cells($label, $name, $selected, $submit_on_change);
 }
 
-function credit_type_list_row($label, $name, $selected=null, $submit_on_change=false)
+function credit_type_list_row($label, $name, $selected = null, $submit_on_change = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	credit_type_list_cells(null, $name, $selected, $submit_on_change);
-	echo "</tr>\n";
+	return ListRenderer::get()->credit_type_list_row($label, $name, $selected, $submit_on_change);
 }
 
-function number_list($name, $selected, $from, $to, $no_option=false)
+function number_list($name, $selected, $from, $to, $no_option = false)
 {
-	$items = array();
-	for ($i = $from; $i <= $to; $i++)
-		$items[$i] = "$i";
-
-	return array_selector($name, $selected, $items,
-			array(	'spec_option' => $no_option,
-					'spec_id' => ALL_NUMERIC) );
+	return ListRenderer::get()->number_list($name, $selected, $from, $to, $no_option);
 }
 
-function number_list_cells($label, $name, $selected, $from, $to, $no_option=false)
+function number_list_cells($label, $name, $selected, $from, $to, $no_option = false)
 {
-	if ($label != null)
-		label_cell($label);
-	echo "<td>\n";
-	echo number_list($name, $selected, $from, $to, $no_option);
-	echo "</td>\n";
+	return ListRenderer::get()->number_list_cells($label, $name, $selected, $from, $to, $no_option);
 }
 
-function number_list_row($label, $name, $selected, $from, $to, $no_option=false)
+function number_list_row($label, $name, $selected, $from, $to, $no_option = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	echo number_list_cells(null, $name, $selected, $from, $to, $no_option);
-	echo "</tr>\n";
+	return ListRenderer::get()->number_list_row($label, $name, $selected, $from, $to, $no_option);
 }
 
-function print_profiles_list_row($label, $name, $selected_id=null, $spec_opt=false,
-	$submit_on_change=true)
+function print_profiles_list_row($label, $name, $selected_id = null, $spec_opt = false, $submit_on_change = true)
 {
-	$sql = "SELECT profile FROM ".TB_PREF."print_profiles"
-		." GROUP BY profile";
-	$result = db_query($sql, 'cannot get all profile names');
-	$profiles = array();
-	while($myrow=db_fetch($result)) {
-		$profiles[$myrow['profile']] = $myrow['profile'];
-	}
-
-	echo "<tr>";
-	if ($label != null)
-		echo "<td class='label'>$label</td>\n";
-	echo "<td>";
-
-	echo array_selector($name, $selected_id, $profiles, 
-		array( 'select_submit'=> $submit_on_change,
-			'spec_option'=>$spec_opt,
-			'spec_id' => ''
-		 ));
-
-	echo "</td></tr>\n";
+	return ListRenderer::get()->print_profiles_list_row($label, $name, $selected_id, $spec_opt, $submit_on_change);
 }
 
-function printers_list($name, $selected_id=null, $spec_opt=false, $submit_on_change=false)
+function printers_list($name, $selected_id = null, $spec_opt = false, $submit_on_change = false)
 {
-	static $printers; // query only once for page display
-
-	if (!$printers) {
-		$sql = "SELECT id, name, description FROM ".TB_PREF."printers";	
-		$result = db_query($sql, 'cannot get all printers');
-		$printers = array();
-		while($myrow=db_fetch($result)) {
-			$printers[$myrow['id']] = $myrow['name'].'&nbsp;-&nbsp;'.$myrow['description'];
-		}
-	}
-	return array_selector($name, $selected_id, $printers, 
-		array( 'select_submit'=> $submit_on_change,
-			'spec_option'=>$spec_opt,
-			'spec_id' => ''
-		 ));
+	return ListRenderer::get()->printers_list($name, $selected_id, $spec_opt, $submit_on_change);
 }
 
-//------------------------------------------------------------------------------------------------
-
-function quick_entries_list($name, $selected_id=null, $type=null, $submit_on_change=false)
+// ------------------------------------------------------------------------------------------------
+function quick_entries_list($name, $selected_id = null, $type = null, $submit_on_change = false)
 {
-	$where = false;
-	$sql = "SELECT id, description FROM ".TB_PREF."quick_entries";
-	if ($type != null)
-		$sql .= " WHERE type=$type";
-
-	return combo_input($name, $selected_id, $sql, 'id', 'description',
-		array(
-			'spec_id' => '',
-			'order' => 'description',
-			'select_submit'=> $submit_on_change,
-			'async' => false
-		) );
-
+	return ListRenderer::get()->quick_entries_list($name, $selected_id, $type, $submit_on_change);
 }
 
-function quick_entries_list_cells($label, $name, $selected_id=null, $type, $submit_on_change=false)
+function quick_entries_list_cells($label, $name, $selected_id = null, $type, $submit_on_change = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";	
-	echo quick_entries_list($name, $selected_id, $type, $submit_on_change);
-	echo "</td>";
+	return ListRenderer::get()->quick_entries_list_cells($label, $name, $selected_id, $type, $submit_on_change);
 }
 
-function quick_entries_list_row($label, $name, $selected_id=null, $type, $submit_on_change=false)
+function quick_entries_list_row($label, $name, $selected_id = null, $type, $submit_on_change = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	quick_entries_list_cells(null, $name, $selected_id, $type, $submit_on_change);
-	echo "</tr>\n";
+	return ListRenderer::get()->quick_entries_list_row($label, $name, $selected_id, $type, $submit_on_change);
 }
 
-
-function quick_actions_list_row($label, $name, $selected_id=null, $submit_on_change=false)
+function quick_actions_list_row($label, $name, $selected_id = null, $submit_on_change = false)
 {
-	global $quick_actions;
-	
-	echo "<tr><td class='label'>$label</td><td>";
-	echo array_selector($name, $selected_id, $quick_actions, 
-		array( 
-			'select_submit'=> $submit_on_change
-		) );
-	echo "</td></tr>\n";
+	return ListRenderer::get()->quick_actions_list_row($label, $name, $selected_id, $submit_on_change);
 }
 
-function quick_entry_types_list_row($label, $name, $selected_id=null, $submit_on_change=false)
+function quick_entry_types_list_row($label, $name, $selected_id = null, $submit_on_change = false)
 {
-	global $quick_entry_types;
-		
-	echo "<tr><td class='label'>$label</td><td>";
-	echo array_selector($name, $selected_id, $quick_entry_types, 
-		array( 
-			'select_submit'=> $submit_on_change
-			) );
-	echo "</td></tr>\n";
+	return ListRenderer::get()->quick_entry_types_list_row($label, $name, $selected_id, $submit_on_change);
 }
 
-function record_status_list_row($label, $name) {
-	return yesno_list_row($label, $name, null, 	_('Inactive'), _('Active'));
-}
-
-function class_types_list_row($label, $name, $selected_id=null, $submit_on_change=false)
+function record_status_list_row($label, $name)
 {
-	global $class_types;
-	
-	echo "<tr><td class='label'>$label</td><td>";
-	echo array_selector($name, $selected_id, $class_types, 
-		array( 
-			'select_submit'=> $submit_on_change
-		) );
-	echo "</td></tr>\n";
+	return ListRenderer::get()->record_status_list_row($label, $name);
 }
 
-//------------------------------------------------------------------------------------------------
-
-function security_roles_list($name, $selected_id=null, $new_item=false, $submit_on_change=false,
-	$show_inactive = false)
+function class_types_list_row($label, $name, $selected_id = null, $submit_on_change = false)
 {
-
-	$sql = "SELECT id, role, inactive FROM ".TB_PREF."security_roles";
-
-	return combo_input($name, $selected_id, $sql, 'id', 'description',
-		array(
-			'spec_option'=>$new_item ? _("New role") : false,
-			'spec_id' => '',
-			'select_submit'=> $submit_on_change,
-			'show_inactive' => $show_inactive
-		) );
+	return ListRenderer::get()->class_types_list_row($label, $name, $selected_id, $submit_on_change);
 }
 
-function security_roles_list_cells($label, $name, $selected_id=null, $new_item=false, $submit_on_change=false,
-	$show_inactive = false)
+// ------------------------------------------------------------------------------------------------
+function security_roles_list($name, $selected_id = null, $new_item = false, $submit_on_change = false, $show_inactive = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo security_roles_list($name, $selected_id, $new_item, $submit_on_change, $show_inactive);
-	echo "</td>\n";
+	return ListRenderer::get()->security_roles_list($name, $selected_id, $new_item, $submit_on_change, $show_inactive);
 }
 
-function security_roles_list_row($label, $name, $selected_id=null, $new_item=false, $submit_on_change=false,
-	$show_inactive = false)
+function security_roles_list_cells($label, $name, $selected_id = null, $new_item = false, $submit_on_change = false, $show_inactive = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	security_roles_list_cells(null, $name, $selected_id, $new_item, $submit_on_change, $show_inactive);
-	echo "</tr>\n";
+	return ListRenderer::get()->security_roles_list_cells($label, $name, $selected_id, $new_item, $submit_on_change, $show_inactive);
 }
 
-function tab_list_row($label, $name, $selected_id=null)
+function security_roles_list_row($label, $name, $selected_id = null, $new_item = false, $submit_on_change = false, $show_inactive = false)
 {
-	global $installed_extensions;
-	
-	$tabs = array();
-	foreach ($_SESSION['App']->applications as $app) {
-		$tabs[$app->id] = access_string($app->name, true);
-	}
-	echo "<tr>\n";
-	echo "<td class='label'>$label</td><td>\n";
-	echo array_selector($name, $selected_id, $tabs);
-	echo "</td></tr>\n";
+	return ListRenderer::get()->security_roles_list_row($label, $name, $selected_id, $new_item, $submit_on_change, $show_inactive);
 }
 
-//-----------------------------------------------------------------------------------------------
-
-function tag_list($name, $height, $type, $multi=false, $all=false, $spec_opt = false)
+function tab_list_row($label, $name, $selected_id = null)
 {
-	// Get tags
-	global $path_to_root;
-	include_once($path_to_root . "/admin/db/tags_db.inc");
-	$results = get_tags($type, $all);
-
-	while ($tag = db_fetch($results))
-		$tags[$tag['id']] = $tag['name'];
-	
-	if (!isset($tags)) {
-		$tags[''] = $all ? _("No tags defined.") : _("No active tags defined.");
-		$spec_opt = false;
-	}
-	return array_selector($name, null, $tags,
-		array(
-			'multi' => $multi,
-			'height' => $height,
-			'spec_option'=> $spec_opt,
-			'spec_id' => -1,
-		) );
+	return ListRenderer::get()->tab_list_row($label, $name, $selected_id);
 }
 
-function tag_list_cells($label, $name, $height, $type, $mult=false, $all=false, $spec_opt = false)
+// -----------------------------------------------------------------------------------------------
+function tag_list($name, $height, $type, $multi = false, $all = false, $spec_opt = false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>\n";
-	echo tag_list($name, $height, $type, $mult, $all, $spec_opt);
-	echo "</td>\n";
-	
+	return ListRenderer::get()->tag_list($name, $height, $type, $multi, $all, $spec_opt);
 }
 
-function tag_list_row($label, $name, $height, $type, $mult=false, $all=false, $spec_opt = false)
+function tag_list_cells($label, $name, $height, $type, $mult = false, $all = false, $spec_opt = false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	tag_list_cells(null, $name, $height, $type, $mult, $all, $spec_opt);
-	echo "</tr>\n";	
+	return ListRenderer::get()->tag_list_cells($label, $name, $height, $type, $mult, $all, $spec_opt);
 }
 
-//---------------------------------------------------------------------------------------------
-//	List of sets of active extensions 
+function tag_list_row($label, $name, $height, $type, $mult = false, $all = false, $spec_opt = false)
+{
+	return ListRenderer::get()->tag_list_row($label, $name, $height, $type, $mult, $all, $spec_opt);
+}
+
+// ---------------------------------------------------------------------------------------------
+// List of sets of active extensions
 //
-function extset_list($name, $value=null, $submit_on_change=false)
+function extset_list($name, $value = null, $submit_on_change = false)
 {
-	global $db_connections;
-
-	$items = array();
-	foreach ($db_connections as $comp)
-		$items[] = sprintf(_("Activated for '%s'"), $comp['name']);
-	return array_selector( $name, $value, $items,
-		array(
-			'spec_option'=> _("Available and/or installed"),
-			'spec_id' => -1,
-			'select_submit'=> $submit_on_change,
-			'async' => true
-		));
+	return ListRenderer::get()->extset_list($name, $value, $submit_on_change);
 }
 
-function crm_category_types_list($name, $selected_id=null, $filter=array(), $submit_on_change=true)
+function crm_category_types_list($name, $selected_id = null, $filter = array(), $submit_on_change = true)
 {
-
-	$sql = "SELECT id, name, type, inactive FROM ".TB_PREF."crm_categories";
-
-	$multi = false;
-	$groups = false;
-	$where = array();
-	if (@$filter['class']) {
-		$where[] = 'type='.db_escape($filter['class']);
-	} else
-		$groups = 'type';
-	if (@$filter['subclass']) $where[] = 'action='.db_escape($filter['subclass']);
-	if (@$filter['entity']) $where[] = 'entity_id='.db_escape($filter['entity']);
-	if (@$filter['multi']) { // contact category selector for person
-		$multi = true;
-	}
-
-	return combo_input($name, $selected_id, $sql, 'id', 'name',
-	 	array(
-	 		'multi' => $multi,
-	 		'height' => $multi ? 5:1,
-			'category' => $groups,
-	 		'select_submit'=> $submit_on_change,
- 			'async' => true,
- 			'where' => $where
-	 	));
+	return ListRenderer::get()->crm_category_types_list($name, $selected_id, $filter, $submit_on_change);
 }
 
-function crm_category_types_list_row($label, $name, $selected_id=null, $filter=array(), $submit_on_change=true)
+function crm_category_types_list_row($label, $name, $selected_id = null, $filter = array(), $submit_on_change = true)
 {
-	echo "<tr><td class='label'>$label</td><td>";
-	echo crm_category_types_list($name, $selected_id, $filter, $submit_on_change);
-	echo "</td></tr>\n";
+	return ListRenderer::get()->crm_category_types_list_row($label, $name, $selected_id, $filter, $submit_on_change);
 }
 
-function payment_type_list_row($label, $name, $selected_id=null, $submit_on_change=false)
+function payment_type_list_row($label, $name, $selected_id = null, $submit_on_change = false)
 {
-	global $pterm_types;
-	
-	echo "<tr><td class='label'>$label</td><td>";
-	echo array_selector($name, $selected_id, $pterm_types, 
-		array( 
-			'select_submit'=> $submit_on_change
-		) );
-	echo "</td></tr>\n";
+	return ListRenderer::get()->payment_type_list_row($label, $name, $selected_id, $submit_on_change);
 }
 
-function coa_list_row($label, $name, $value=null)
+function coa_list_row($label, $name, $value = null)
 {
-	global $path_to_root, $installed_extensions;
-
-	$path = $path_to_root.'/sql/';
-	$coas = array();
-	$sqldir = opendir($path);
-	while (false !== ($fname = readdir($sqldir)))
-	{
-		if (is_file($path.$fname) && substr($fname,-4)=='.sql' && @($fname[2] == '_'))
-		{
-			$ext = array_search_value($fname, $installed_extensions, 'sql');
-			if ($ext!=null) {
-				$descr = $ext['name'];
-			} elseif ($fname == 'en_US-new.sql') { // two standard COAs
-				$descr = _("Standard new company American COA (4 digit)");
-			} elseif ($fname == 'en_US-demo.sql') {
-				$descr = _("Standard American COA (4 digit) with demo data");
-			} else
-				$descr = $fname;
-
-			$coas[$fname] =  $descr;
-		}
-	}
-	ksort($coas);
-
-	echo "<tr><td class='label'>$label</td>\n<td>";
-	echo array_selector( $name, $value, $coas );
-	echo "</td></tr>\n";
+	return ListRenderer::get()->coa_list_row($label, $name, $value);
 }
 
 function payment_services($name)
 {
-	global $payment_services;
-
-	$services = array_combine(array_keys($payment_services), array_keys($payment_services));
-
-	return array_selector($name, null, $services, array(
-			'spec_option'=> _("No payment Link"),
-			'spec_id' => '',
-		));
+	return ListRenderer::get()->payment_services($name);
 }
 
 function tax_algorithm_list($name, $value=null, $submit_on_change = false)
 {
-	global $tax_algorithms;
-	
-	return array_selector($name, $value, $tax_algorithms, 
-		array( 
-			'select_submit'=> $submit_on_change,
-			'async' => true,
-			)
-	);
+	return ListRenderer::get()->tax_algorithm_list($name, $value, $submit_on_change);
 }
 
 function tax_algorithm_list_cells($label, $name, $value=null, $submit_on_change=false)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td>";
-	echo tax_algorithm_list($name, $value, $submit_on_change);
-	echo "</td>\n";
+	ListRenderer::get()->tax_algorithm_list_cells($label, $name, $value, $submit_on_change);
 }
 
 function tax_algorithm_list_row($label, $name, $value=null, $submit_on_change=false)
 {
-	echo "<tr><td class='label'>$label</td>";
-	tax_algorithm_list_cells(null, $name, $value, $submit_on_change);
-	echo "</tr>\n";
+	ListRenderer::get()->tax_algorithm_list_row($label, $name, $value, $submit_on_change);
 }
 
 function refline_list($name, $type, $value=null, $spec_option=false)
 {
-	$sql = "SELECT id, prefix, inactive FROM ".TB_PREF."reflines";
-
-	$where = array();
-
-	if (isset($type))
-		$where = array('`trans_type`='.db_escape($type));
-
-	return combo_input($name, $value, $sql, 'id', 'prefix',
-		array(
-			'order'=>array('prefix'),
-			'spec_option' => $spec_option,
-			'spec_id' => '',
-			'type' => 2,
-			'where' => $where,
-			'select_submit' => true,
-			)
-		);
+	return ListRenderer::get()->refline_list($name, $type, $value, $spec_option);
 }
 
 function refline_list_row($label, $name, $type, $selected_id=null, $spec_option=false)
 {
-	echo "<tr>";
-	if ($label != null)
-		echo "<td class='label'>$label</td>\n";
-	echo "<td>";
-
-	echo refline_list($name, $type, $selected_id, $spec_option);
-	echo "</td></tr>\n";
+	ListRenderer::get()->refline_list_row($label, $name, $type, $selected_id, $spec_option);
 }
-
 
 //----------------------------------------------------------------------------------------------
 
 function subledger_list($name, $account, $selected_id=null)
 {
-
-	$type = is_subledger_account($account);
-	if (!$type)
-		return '';
-
-	if($type > 0)
-		$sql = "SELECT DISTINCT d.debtor_no as id, debtor_ref as name 
-		FROM "
-		.TB_PREF."debtors_master d,"
-		.TB_PREF."cust_branch c
-		WHERE d.debtor_no=c.debtor_no AND c.receivables_account=".db_escape($account);
-	else
-		$sql = "SELECT supplier_id as id, supp_ref as name 
-		FROM "
-		.TB_PREF."suppliers s
-		WHERE s.payable_account=".db_escape($account);
-
-	$mode = get_company_pref('no_customer_list');
-
-	return combo_input($name, $selected_id, $sql, 'id', 'name',
-	array(
-		'type' => 1,
-		'size' => 20,
-		'async' => false,
-	) );
+	return ListRenderer::get()->subledger_list($name, $account, $selected_id);
 }
 
 function subledger_list_cells($label, $name, $account, $selected_id=null)
 {
-	if ($label != null)
-		echo "<td>$label</td>\n";
-	echo "<td nowrap>";
-	echo subledger_list($name, $account, $selected_id);
-	echo "</td>\n";
+	ListRenderer::get()->subledger_list_cells($label, $name, $account, $selected_id);
 }
 
-function subledger_list_row($label, $name, $selected_id=null, $all_option = false, 
+function subledger_list_row($label, $name, $selected_id=null, $all_option = false,
 	$submit_on_change=false, $show_inactive=false, $editkey = false)
 {
-	echo "<tr><td class='label'>$label</td><td nowrap>";
-	echo subledger_list($name, $account, $selected_id);
-	echo "</td>\n</tr>\n";
+	ListRenderer::get()->subledger_list_row($label, $name, $selected_id, $all_option, $submit_on_change, $show_inactive, $editkey);
 }
 
 function accounts_type_list_row($label, $name, $selected_id=null)
 {
-	echo "<tr>";
-	if ($label != null)
-		echo "<td class='label'>$label</td>\n";
-	echo "<td>";
-	$sel = array(_("Numeric"), _("Alpha Numeric"), _("ALPHA NUMERIC"));
-	echo array_selector($name, $selected_id, $sel); 
-	echo "</td></tr>\n";
+	ListRenderer::get()->accounts_type_list_row($label, $name, $selected_id);
 }
 
 function users_list_cells($label, $name, $selected_id=null, $submit_on_change=false, $spec_opt=true)
 {
-    $where = false;
-    $sql = " SELECT user_id, real_name FROM ".TB_PREF."users";
-
-    if ($label != null)
-        echo "<td>$label</td>\n";
-    echo "<td>";
-
-    echo combo_input($name, $selected_id, $sql, 'user_id', 'real_name',
-        array(
-            'spec_option' => $spec_opt===true ?_("All users") : $spec_opt,
-            'spec_id' => '',
-            'order' => 'real_name',
-            'select_submit'=> $submit_on_change,
-            'async' => false
-        ) );
-    echo "</td>";
-
+	ListRenderer::get()->users_list_cells($label, $name, $selected_id, $submit_on_change, $spec_opt);
 }
 
 function collations_list_row($label, $name, $selected_id=null)
 {
-	global $supported_collations;
-
-	echo "<tr>";
-	if ($label != null)
-		echo "<td class='label'>$label</td>\n";
-	echo "<td>";
-
-	echo array_selector($name, $selected_id, $supported_collations, 
-		array('select_submit'=> false) );
-	echo "</td></tr>\n";
+	ListRenderer::get()->collations_list_row($label, $name, $selected_id);
 }
+
+?>

--- a/includes/ui/ui_view.inc
+++ b/includes/ui/ui_view.inc
@@ -395,10 +395,8 @@ function view_stock_status($stock_id, $description=null, $echo=true)
 
 function view_stock_status_cell($stock_id, $description=null)
 {
-	echo "<td>";
-	view_stock_status($stock_id, $description);
-	echo "</td>";
-}
+	$control = view_stock_status($stock_id, $description, false);
+	label_cell($control);}
 
 //--------------------------------------------------------------------------------------
 

--- a/inventory/inquiry/stock_status.php
+++ b/inventory/inquiry/stock_status.php
@@ -42,12 +42,14 @@ if (!isset($_POST['stock_id']))
 
 if (!$page_nested)
 {
-	echo "<center> " . _("Item:"). " ";
-	echo stock_costable_items_list('stock_id', $_POST['stock_id'], false, true);
+//	echo "<center> " . _("Item:"). " ";
+//	echo stock_costable_items_list('stock_id', $_POST['stock_id'], false, true);
+	ControlRenderer::get()->table_add_cells(array(_("Item:"), stock_costable_items_list('stock_id', $_POST['stock_id'], false, true)));
+	end_form();
 }
-echo "<br>";
+//echo "<br>";
 
-echo "<hr></center>";
+//echo "<hr></center>";
 
 set_global_stock_item($_POST['stock_id']);
 


### PR DESCRIPTION
This pull request introduces rendering classes so that the actual rendering of html elements can be delegated to themes where required.  The PR is intended to be a minimal change to achieve this effect.  The changes diff well with the existing implementation e.g. ui_control.inc <-> ControlRenderer.inc which in turn diffs well with the separate bootstrap theme implementation.  This simplifies maintaining the feature until such time as it is integrated into FA.  Once integrated I would refactor further to improve the rendering code both for the default themes and the bootstrap theme.