### PR TITLE
feature/PaymentAccount:  Make default account same as earlier transacion

### DIFF
--- a/purchasing/includes/db/supp_trans_db.inc
+++ b/purchasing/includes/db/supp_trans_db.inc
@@ -106,6 +106,48 @@ function get_supp_trans($trans_no, $trans_type=-1)
 
 //----------------------------------------------------------------------------------------
 
+function get_supp_payment_before($supplier_id, $date)
+{
+	$sql = "SELECT "
+	. TB_PREF . "supp_trans.trans_no,"
+	. TB_PREF . "supp_trans.type,"
+	. TB_PREF . "supp_trans.supplier_id,"
+	. TB_PREF . "supp_trans.tran_date,"
+	. TB_PREF . "supp_trans.ov_amount,"
+	. TB_PREF . "bank_trans.ref AS bank_ref,"
+	. TB_PREF . "bank_trans.amount AS bank_amount,"
+	. TB_PREF . "bank_accounts.id AS bank_id,"
+	. TB_PREF . "bank_accounts.bank_name,"
+	. TB_PREF . "bank_accounts.bank_account_name,"
+	. TB_PREF . "bank_accounts.bank_curr_code "
+	. "FROM "
+	. TB_PREF . "supp_trans,"
+	. TB_PREF . "bank_trans,"
+	. TB_PREF . "bank_accounts "
+	. "WHERE "
+	. TB_PREF . "supp_trans.supplier_id=" . $supplier_id . " "
+	. "AND " . TB_PREF . "supp_trans.tran_date<'" . $date . "' "
+	. "AND " . TB_PREF . "supp_trans.type=" . ST_SUPPAYMENT . " "
+	. "AND " . TB_PREF . "supp_trans.trans_no=" . TB_PREF . "bank_trans.trans_no "
+	. "AND " . TB_PREF . "supp_trans.type=" . TB_PREF . "bank_trans.type "
+	. "AND " . TB_PREF . "bank_accounts.id=" . TB_PREF . "bank_trans.bank_act "
+	. "ORDER BY "
+	. TB_PREF . "supp_trans.tran_date DESC "
+	. "LIMIT 1 "
+	;
+
+	$result = db_query($sql, "Cannot retreive a previous supplier payment");
+
+	if (db_num_rows($result) == 0)
+	{
+		return false;
+	}
+
+	return db_fetch($result);
+}
+
+//----------------------------------------------------------------------------------------
+
 function exists_supp_trans($type, $type_no)
 {
 	if ($type == ST_SUPPRECEIVE)

--- a/purchasing/supplier_payment.php
+++ b/purchasing/supplier_payment.php
@@ -72,8 +72,6 @@ if (!isset($_POST['bank_account'])) { // first page call
 	if (isset($_GET['PInvoice'])) {
 		//  get date and supplier
 		$inv = get_supp_trans($_GET['PInvoice'], ST_SUPPINVOICE);
-		$dflt_act = get_default_bank_account($inv['curr_code']);
-		$_POST['bank_account'] = $dflt_act['id'];
 		if($inv) {
 			$_SESSION['alloc']->person_id = $_POST['supplier_id'] = $inv['supplier_id'];
 			$_SESSION['alloc']->read();
@@ -112,6 +110,17 @@ if (isset($_GET['AddedID'])) {
 	display_footer_exit();
 }
 
+//----------------------------------------------------------------------------------------
+
+function get_default_supplier_payment_bank_account($supplier_id, $date)
+{
+	$previous_payment = get_supp_payment_before($supplier_id, date2sql($date));
+	if ($previous_payment)
+	{
+		return $previous_payment['bank_id'];
+	}
+	return get_default_supplier_bank_account($supplier_id);
+}
 //----------------------------------------------------------------------------------------
 
 function check_inputs()
@@ -283,9 +292,12 @@ start_form();
 	set_global_supplier($_POST['supplier_id']);
 
 	if (!list_updated('bank_account') && !get_post('__ex_rate_changed'))
-		$_POST['bank_account'] = get_default_supplier_bank_account($_POST['supplier_id']);
-	else
+	{
+		$_POST['bank_account'] = get_default_supplier_payment_bank_account($_POST['supplier_id'], $_POST['DatePaid']);
+	} else
+	{
 		$_POST['amount'] = price_format(0);
+	}
 
     bank_accounts_list_row(_("From Bank Account:"), 'bank_account', null, true);
 


### PR DESCRIPTION
This is the same as PR #10 but based on the master branch for FA 2.3.x

- The default bank account is selected to be the same as that used on the
  immediately preceding transaction for the supplier. Otherwise the default
  bank account for the currency is used.