### PR TITLE
Retrieve QE & Misc names on bank reconcile and statement

### DIFF
--- a/gl/bank_account_reconcile.php
+++ b/gl/bank_account_reconcile.php
@@ -87,7 +87,7 @@ function fmt_credit($row)
 
 function fmt_person($trans)
 {
-	return get_counterparty_name($trans["type"], $trans["trans_no"]);
+     return payment_person_name($trans["person_type_id"],$trans["person_id"]);
 }
 
 function fmt_memo($row)

--- a/reporting/rep601.php
+++ b/reporting/rep601.php
@@ -125,7 +125,7 @@ function print_bank_transactions()
 				$rep->TextCol(1, 2,	$myrow['trans_no']);
 				$rep->TextCol(2, 3,	$myrow['ref']);
 				$rep->DateCol(3, 4,	$myrow["trans_date"], true);
-				$rep->TextCol(4, 5,	get_counterparty_name($myrow["type"], $myrow["trans_no"], false));
+                                $rep->TextCol(4, 5,     payment_person_name($myrow["person_type_id"],$myrow["person_id"]));
 				if ($myrow['amount'] > 0.0)
 				{
 					$rep->AmountCol(5, 6, abs($myrow['amount']), $dec);


### PR DESCRIPTION
Bank reconcile and the bank statement report do not print quickentry and miscellaneous names.   It is because they call the wrong function, get_counterparty_name(), which derives supplier and customer names from transaction type and no.  But a bank trans already has the person type and id, and only needs to call payment_person_name() to get a name of any type.