### PR TITLE
Add frequently used dates to date picker

### DIFF
--- a/gl/bank_account_reconcile.php
+++ b/gl/bank_account_reconcile.php
@@ -87,7 +87,7 @@ function fmt_credit($row)
 
 function fmt_person($trans)
 {
-	return get_counterparty_name($trans["type"], $trans["trans_no"]);
+     return payment_person_name($trans["person_type_id"],$trans["person_id"]);
 }
 
 function fmt_memo($row)

--- a/includes/ui/ui_view.inc
+++ b/includes/ui/ui_view.inc
@@ -982,7 +982,10 @@ function get_js_date_picker()
 	$months = array(_("January"),_("February"),_("March"),_("April"),_("May"),_("June"),_("July"),_("August"),_("September"),_("October"),_("November"),_("December"));
 	$wdays = array(_("Su"),_("Mo"),_("Tu"),_("We"),_("Th"),_("Fr"),_("Sa"));
 	$wno = _("W"); // week no
-	$back = _("Back");
+	$yearstart = _("Start Of Year");
+	$yearend = _("End Of Year");
+	$lastyearstart = _("Start Of Last Year");
+	$lastyearend = _("End Of Last Year");
 	if ($date_system == 1)
 		list($cyear, $cmon, $cday) = gregorian_to_jalali(date("Y"), date("n"), date("j"));
 	elseif ($date_system == 2)
@@ -1304,7 +1307,14 @@ function CC() {
       }
       table += \"</tr>\";
     }
-    table += \"<tr class='header'><th colspan='8' style='padding: 3px;text-align:center;'><a href='javascript:hideCC();'>$back</a></td></tr>\";
+    if (dateField.name.indexOf(\"After\") != -1) {
+        table += \"<tr class='header'><th colspan='8' style='padding: 3px;text-align:center;'><a href=\\\"javascript:setCCDate(\"+thisYear+\",\"+1+\",\"+1+\")\\\">\"+\"$yearstart</a></td></tr>\";
+        table += \"<tr class='header'><th colspan='8' style='padding: 3px;text-align:center;'><a href=\\\"javascript:setCCDate(\"+lastYear+\",\"+1+\",\"+1+\")\\\">\"+\"$lastyearstart</a></td></tr>\";
+    }
+    if (dateField.name.indexOf(\"To\") != -1) {
+        table += \"<tr class='header'><th colspan='8' style='padding: 3px;text-align:center;'><a href=\\\"javascript:setCCDate(\"+thisYear+\",\"+12+\",\"+31+\")\\\">\"+\"$yearend</a></td></tr>\";
+        table += \"<tr class='header'><th colspan='8' style='padding: 3px;text-align:center;'><a href=\\\"javascript:setCCDate(\"+lastYear+\",\"+12+\",\"+31+\")\\\">\"+\"$lastyearend</a></td></tr>\";
+    }
     table += \"</table>\";
     return table;
   }
@@ -1383,6 +1393,10 @@ function CC() {
     currentMonth = selectedMonth;
     currentDay = selectedDay;
     currentYear = selectedYear;
+    thisMonth = getCurrentMonth();
+    thisYear = getCurrentYear();
+    endMonth =  getDaysInMonth(thisYear, thisMonth);
+    lastYear = thisYear - 1;
     if(document.getElementById){
       calendar = document.getElementById(calendarId);
       calendar.innerHTML = calendarDrawTable(currentYear, currentMonth);
@@ -1419,7 +1433,10 @@ function CC() {
 }
 var cC = new CC();
 function date_picker(textField) {
-  cC.show(textField);
+  if (cC.visible()) {
+    cC.hide();
+  } else
+    cC.show(textField);
 }
 function hideCC() {
   if (cC.visible()) {

--- a/includes/ui/ui_view.inc
+++ b/includes/ui/ui_view.inc
@@ -1062,6 +1062,7 @@ function CC() {
   var selectedYear = 0;
   var selectedMonth = 0;
   var selectedDay = 0;
+  var toDate = false;
   var months = ['$months[0]','$months[1]','$months[2]','$months[3]','$months[4]','$months[5]','$months[6]','$months[7]','$months[8]','$months[9]','$months[10]','$months[11]'];
   var wdays = ['$wdays[0]', '$wdays[1]', '$wdays[2]', '$wdays[3]', '$wdays[4]', '$wdays[5]', '$wdays[6]'];
   var tmonths = ['$tmonths[0]','$tmonths[1]','$tmonths[2]','$tmonths[3]','$tmonths[4]','$tmonths[5]','$tmonths[6]','$tmonths[7]','$tmonths[8]','$tmonths[9]','$tmonths[10]','$tmonths[11]','$tmonths[12]'];
@@ -1307,19 +1308,19 @@ function CC() {
       }
       table += \"</tr>\";
     }
-    if (dateField.name.indexOf(\"After\") != -1) {
-        table += \"<tr class='header'><th colspan='8' style='padding: 3px;text-align:center;'><a href=\\\"javascript:setCCDate(\"+thisYear+\",\"+1+\",\"+1+\")\\\">\"+\"$yearstart</a></td></tr>\";
-        table += \"<tr class='header'><th colspan='8' style='padding: 3px;text-align:center;'><a href=\\\"javascript:setCCDate(\"+lastYear+\",\"+1+\",\"+1+\")\\\">\"+\"$lastyearstart</a></td></tr>\";
-    }
-    if (dateField.name.indexOf(\"To\") != -1) {
+    if (toDate) {
         table += \"<tr class='header'><th colspan='8' style='padding: 3px;text-align:center;'><a href=\\\"javascript:setCCDate(\"+thisYear+\",\"+12+\",\"+31+\")\\\">\"+\"$yearend</a></td></tr>\";
         table += \"<tr class='header'><th colspan='8' style='padding: 3px;text-align:center;'><a href=\\\"javascript:setCCDate(\"+lastYear+\",\"+12+\",\"+31+\")\\\">\"+\"$lastyearend</a></td></tr>\";
+    } else {
+        table += \"<tr class='header'><th colspan='8' style='padding: 3px;text-align:center;'><a href=\\\"javascript:setCCDate(\"+thisYear+\",\"+1+\",\"+1+\")\\\">\"+\"$yearstart</a></td></tr>\";
+        table += \"<tr class='header'><th colspan='8' style='padding: 3px;text-align:center;'><a href=\\\"javascript:setCCDate(\"+lastYear+\",\"+1+\",\"+1+\")\\\">\"+\"$lastyearstart</a></td></tr>\";
     }
     table += \"</table>\";
     return table;
   }
   this.show = show;
-  function show(field) {
+  function show(field, todate) {
+    toDate = todate;
     can_hide = 0;
     if (dateField == field) {
       return;
@@ -1399,7 +1400,7 @@ function CC() {
     lastYear = thisYear - 1;
     if(document.getElementById){
       calendar = document.getElementById(calendarId);
-      calendar.innerHTML = calendarDrawTable(currentYear, currentMonth);
+      calendar.innerHTML = calendarDrawTable();
       var fieldPos = new positionInfo(dateField);
       var calendarPos = new positionInfo(calendarId);
       var x = fieldPos.getElementLeft();
@@ -1432,11 +1433,11 @@ function CC() {
   var can_hide = 0;
 }
 var cC = new CC();
-function date_picker(textField) {
+function date_picker(textField, todate = (textField.name.indexOf(\"To\") != -1)) {
   if (cC.visible()) {
     cC.hide();
   } else
-    cC.show(textField);
+    cC.show(textField, todate);
 }
 function hideCC() {
   if (cC.visible()) {

--- a/reporting/includes/reports_classes.inc
+++ b/reporting/includes/reports_classes.inc
@@ -217,9 +217,10 @@ class BoxReports
 					$st = "<input type='text' name='$name' value='$date'>";
 					if (user_use_date_picker())
 					{
+                                                $todate = strpos($type, "END") !== false ? true : false;
 						$calc_image = (file_exists("$path_to_root/themes/".user_theme()."/images/cal.gif")) ? 
 							"$path_to_root/themes/".user_theme()."/images/cal.gif" : "$path_to_root/themes/default/images/cal.gif";
-						$st .= "<a href=\"javascript:date_picker(document.forms[0].$name);\">"
+						$st .= "<a href=\"javascript:date_picker(document.forms[0].$name, $todate);\">"
 						. "	<img src='$calc_image' style='vertical-align:middle;padding-bottom:4px;width:16px;height:16px;border:0;' alt='"._('Click Here to Pick up the date')."'></a>\n";
 					}	
 					return $st;

--- a/reporting/rep601.php
+++ b/reporting/rep601.php
@@ -125,7 +125,7 @@ function print_bank_transactions()
 				$rep->TextCol(1, 2,	$myrow['trans_no']);
 				$rep->TextCol(2, 3,	$myrow['ref']);
 				$rep->DateCol(3, 4,	$myrow["trans_date"], true);
-				$rep->TextCol(4, 5,	get_counterparty_name($myrow["type"], $myrow["trans_no"], false));
+                                $rep->TextCol(4, 5,     payment_person_name($myrow["person_type_id"],$myrow["person_id"]));
 				if ($myrow['amount'] > 0.0)
 				{
 					$rep->AmountCol(5, 6, abs($myrow['amount']), $dec);


### PR DESCRIPTION
This mod updates the date picker to add frequently picked dates at the bottom of the date picker.  Frequently, a person wants to review activity for the entire year or prior year.    The current date picker does not offer these options, and requires so many clicks to to get these dates, that it is easier not to use the date picker and just enter the dates using the text interface. 

This mod places these dates at the bottom of the date picker.  It also removes the Back button, which is replaced by clicking on the date picker again, to hide or show it (i.e. toggle).  Toggling is an expected behaviour by web users, as they have become accustomed to toggling the display of select menus.