### PR TITLE
Update inst_lang.php

### DIFF
--- a/admin/inst_lang.php
+++ b/admin/inst_lang.php
@@ -136,7 +136,7 @@ function check_data()
 		return false;
 	}
 	$id = array_search_value($_POST['code'], $installed_languages, 'code');
-	if ($id !== null && $installed_languages[$id]['package'] != null) {
+	if ($id !== null && $id['package'] != null) {
 		display_error(_('Standard package for this language is already installed. If you want to install this language manually, uninstall standard language package first.'));
 		return false;
 	}


### PR DESCRIPTION
Fix for:
Illegal offset type in file: inst_lang.php at line 139

If you have error reporting enabled, you get this error when installing a language, at least manually.   While the error can be ignored because the language successfully installs, it is disconcerting.