### PR TITLE
Add dimension to customer payments

### DIFF
--- a/sales/customer_payments.php
+++ b/sales/customer_payments.php
@@ -240,7 +240,7 @@ if (get_post('AddPaymentItem') && can_process()) {
         $row = get_customer($_POST['customer_id']);
 	$payment_no = write_customer_payment($_SESSION['alloc']->trans_no, $_POST['customer_id'], $_POST['BranchID'],
 		$_POST['bank_account'], $_POST['DateBanked'], $_POST['ref'],
-                input_num('amount'), input_num('discount'), $_POST['memo_'], 0, input_num('charge'), input_num('bank_amount', input_num('amount')), $row['dimension_id'], $row[$dimension2_id]);
+                input_num('amount'), input_num('discount'), $_POST['memo_'], 0, input_num('charge'), input_num('bank_amount', input_num('amount')), $row['dimension_id'], $row['dimension2_id']);
 
 
 	$_SESSION['alloc']->trans_no = $payment_no;

--- a/sales/customer_payments.php
+++ b/sales/customer_payments.php
@@ -237,10 +237,11 @@ if (get_post('AddPaymentItem') && can_process()) {
 	new_doc_date($_POST['DateBanked']);
 
 	$new_pmt = !$_SESSION['alloc']->trans_no;
-	//Chaitanya : 13-OCT-2011 - To support Edit feature
+        $row = get_customer($_POST['customer_id']);
 	$payment_no = write_customer_payment($_SESSION['alloc']->trans_no, $_POST['customer_id'], $_POST['BranchID'],
 		$_POST['bank_account'], $_POST['DateBanked'], $_POST['ref'],
-		input_num('amount'), input_num('discount'), $_POST['memo_'], 0, input_num('charge'), input_num('bank_amount', input_num('amount')));
+                input_num('amount'), input_num('discount'), $_POST['memo_'], 0, input_num('charge'), input_num('bank_amount', input_num('amount')), $row['dimension_id'], $row[$dimension2_id]);
+
 
 	$_SESSION['alloc']->trans_no = $payment_no;
 	$_SESSION['alloc']->write();

--- a/sales/includes/db/payment_db.inc
+++ b/sales/includes/db/payment_db.inc
@@ -21,14 +21,14 @@
 	$charge - in bank currency
 */
 function write_customer_payment($trans_no, $customer_id, $branch_id, $bank_account,
-	$date_, $ref, $amount, $discount, $memo_, $rate=0, $charge=0, $bank_amount=0)
+	$date_, $ref, $amount, $discount, $memo_, $rate=0, $charge=0, $bank_amount=0, $dim1=0, $dim2=0)
 {
 	global $Refs;
 
 	begin_transaction();
-	$args = func_get_args(); while (count($args) < 12) $args[] = 0;
+	$args = func_get_args(); while (count($args) < 14) $args[] = 0;
 	$args = (object)array_combine(array('trans_no', 'customer_id', 'branch_id', 'bank_account', 
-		'date_', 'ref', 'amount', 'discount', 'memo_','rate','charge', 'bank_amount'), $args);
+		'date_', 'ref', 'amount', 'discount', 'memo_','rate','charge', 'bank_amount', 'dim1', 'dim2'), $args);
 	hook_db_prewrite($args, ST_CUSTPAYMENT);
 
 	$company_record = get_company_prefs();
@@ -61,7 +61,7 @@ function write_customer_payment($trans_no, $customer_id, $branch_id, $bank_accou
 
 	/* Bank account entry first */
 	$total += add_gl_trans(ST_CUSTPAYMENT, $payment_no, $date_,
-		$bank_gl_account, 0, 0, '', ($bank_amount - $charge),  $bank['bank_curr_code'], PT_CUSTOMER, $customer_id);
+		$bank_gl_account, $dim1, $dim2, '', ($bank_amount - $charge),  $bank['bank_curr_code'], PT_CUSTOMER, $customer_id);
 
 	if ($branch_id != ANY_NUMERIC) {
 
@@ -78,20 +78,20 @@ function write_customer_payment($trans_no, $customer_id, $branch_id, $bank_accou
 	if (($discount + $amount) != 0)	{
 	/* Now Credit Debtors account with receipts + discounts */
 	$total += add_gl_trans_customer(ST_CUSTPAYMENT, $payment_no, $date_,
-		$debtors_account, 0, 0, -($discount + $amount), $customer_id,
+		$debtors_account, $dim1, $dim2, -($discount + $amount), $customer_id,
 		"Cannot insert a GL transaction for the debtors account credit");
 	}
 	if ($discount != 0)	{
 		/* Now Debit discount account with discounts allowed*/
 		$total += add_gl_trans_customer(ST_CUSTPAYMENT, $payment_no, $date_,
-			$discount_account, 0, 0, $discount, $customer_id,
+			$discount_account, $dim1, $dim2, $discount, $customer_id,
 			"Cannot insert a GL transaction for the payment discount debit");
 	}
 
 	if ($charge != 0)	{
 		/* Now Debit bank charge account with charges */
 		$charge_act = get_bank_charge_account($bank_account);
-		$total += add_gl_trans(ST_CUSTPAYMENT, $payment_no, $date_,	$charge_act, 0, 0, '', 
+		$total += add_gl_trans(ST_CUSTPAYMENT, $payment_no, $date_,	$charge_act, $dim1, $dim2, '', 
 			$charge, $bank['bank_curr_code'], PT_CUSTOMER,  $customer_id);
 	}
 
@@ -100,7 +100,7 @@ function write_customer_payment($trans_no, $customer_id, $branch_id, $bank_accou
 	if ($total != 0)
 	{
 		$variance_act = get_company_pref('exchange_diff_act');
-		add_gl_trans(ST_CUSTPAYMENT, $payment_no, $date_,	$variance_act, 0, 0, '',
+		add_gl_trans(ST_CUSTPAYMENT, $payment_no, $date_,	$variance_act, $dim1, $dim2, '',
 			-$total, null, PT_CUSTOMER,  $customer_id);
 	}
 

--- a/sales/includes/db/sales_invoice_db.inc
+++ b/sales/includes/db/sales_invoice_db.inc
@@ -204,7 +204,7 @@ function write_sales_invoice(&$invoice)
 					'branch' => $invoice->Branch, 'date' => $date_)),
 				$amount-$discount, $discount,
 				$invoice->pos['pos_name'].' #'.$invoice_no,
-                                0,0,0,$dim, $dim2);
+                                0,0,0,$invoice->dimension_id, $invoice->dimension2_id);
 			add_cust_allocation($amount, ST_CUSTPAYMENT, $pmtno, ST_SALESINVOICE, $invoice_no, $invoice->customer_id, $date_);
 
 			update_debtor_trans_allocation(ST_SALESINVOICE, $invoice_no, $invoice->customer_id);

--- a/sales/includes/db/sales_invoice_db.inc
+++ b/sales/includes/db/sales_invoice_db.inc
@@ -158,14 +158,14 @@ function write_sales_invoice(&$invoice)
 	} /*end of delivery_line loop */
 
 	if (($items_total + $charge_shipping) != 0) {
-		$total += add_gl_trans_customer(ST_SALESINVOICE, $invoice_no, $date_, $branch_data["receivables_account"], 0, 0,
+		$total += add_gl_trans_customer(ST_SALESINVOICE, $invoice_no, $date_, $branch_data["receivables_account"], $invoice->dimension_id, $invoice->dimension2_id,
 			($items_total + $charge_shipping + $items_added_tax + $freight_added_tax)*$prepaid_factor,
 			$invoice->customer_id, "The total debtor GL posting could not be inserted");
 	}
 	$to_allocate = ($items_total + $charge_shipping + $items_added_tax + $freight_added_tax);
 
 	if ($charge_shipping != 0) {
-		$total += add_gl_trans_customer(ST_SALESINVOICE, $invoice_no, $date_, $company_data["freight_act"], 0, 0,
+		$total += add_gl_trans_customer(ST_SALESINVOICE, $invoice_no, $date_, $company_data["freight_act"], $invoice->dimension_id, $invoice->dimension2_id,
 			-$invoice->get_tax_free_shipping()*$prepaid_factor, $invoice->customer_id,
 			"The freight GL posting could not be inserted");
 	}
@@ -177,7 +177,7 @@ function write_sales_invoice(&$invoice)
 				$taxitem['rate'], $invoice->tax_included, $prepaid_factor*$taxitem['Value'],
 				 $taxitem['Net'], $ex_rate, $date_, $invoice->reference, TR_OUTPUT);
 			if (isset($taxitem['sales_gl_code']))
-				$total += add_gl_trans_customer(ST_SALESINVOICE, $invoice_no, $date_, $taxitem['sales_gl_code'], 0, 0,
+				$total += add_gl_trans_customer(ST_SALESINVOICE, $invoice_no, $date_, $taxitem['sales_gl_code'],$invoice->dimension_id , $invoice->dimension2_id,
 					(-$taxitem['Value'])*$prepaid_factor, $invoice->customer_id,
 					"A tax GL posting could not be inserted");
 		}
@@ -203,7 +203,8 @@ function write_sales_invoice(&$invoice)
 				$Refs->get_next(ST_CUSTPAYMENT, null, array('customer' => $invoice->customer_id,
 					'branch' => $invoice->Branch, 'date' => $date_)),
 				$amount-$discount, $discount,
-				$invoice->pos['pos_name'].' #'.$invoice_no);
+				$invoice->pos['pos_name'].' #'.$invoice_no,
+                                0,0,0,$dim, $dim2);
 			add_cust_allocation($amount, ST_CUSTPAYMENT, $pmtno, ST_SALESINVOICE, $invoice_no, $invoice->customer_id, $date_);
 
 			update_debtor_trans_allocation(ST_SALESINVOICE, $invoice_no, $invoice->customer_id);


### PR DESCRIPTION
Currently, when a sale is made in FA, FA correctly will assign a dimension to the gl Sales and Accounts Receivable accounts.   However, when a payment is received, it neglects to assign a dimension to the gl Accounts Receivable and Bank accounts. 

Thus, the gl A/R account for a dimension will rise ad infinitum as sales and payments are made.  (Although A/R for all dimensions is correct, which is why those who do not use dimensions do not see this effect).

This mod assigns dimension to customer payments, which corrects dimensioned A/R.