### PR TITLE
add total equities line to balance sheet report

### DIFF
--- a/reporting/rep706.php
+++ b/reporting/rep706.php
@@ -286,6 +286,20 @@ function print_balance_sheet()
 	$rep->AmountCol(4, 5, $calc_open + $calc_period, $dec);
 	$rep->NewLine(2);
 
+        if ($equity_open != 0 || $equity_period != 0) {
+            //Print Class Summary      
+            $rep->row += 6;
+            $rep->Line($rep->row);
+            $rep->NewLine();
+            $rep->Font('bold');
+            $rep->TextCol(0, 2,        _('Total') . " " . _('Equities'));
+            $rep->AmountCol(2, 3, $calc_open + $class_open_total * $econvert, $dec);
+            $rep->AmountCol(3, 4, $calc_period + $class_period_total * $econvert, $dec);
+            $rep->AmountCol(4, 5, ($calc_open + $calc_period + ($class_open_total + $class_period_total) * $econvert), $dec);
+            $rep->Font();
+            $rep->NewLine(2);
+        }
+
 	$rep->Font('bold');	
 	$rep->TextCol(0, 2,	_('Total') . " " . _('Liabilities') . _(' and ') . _('Equities'));
 	$topen = $equity_open * $econvert + $liability_open * $lconvert + $calc_open;


### PR DESCRIPTION
The balance sheet report is missing a subtotal.  It displays a Total Liabilities and Equities line at the bottom, which is a grand total of the Liabilities, Total Equity and Calculated Return.

This mod adds a Total Equities line to the report, which is equal to Total Equity and Calculated Return, which is the actual shareholder equity during the period.

With this mod, the Total Liabilities and Equities line then makes obvious sense.