### PR TITLE
BUG FIX: supplier inquiry GRN items filter by date

### DIFF
--- a/purchasing/includes/db/supp_trans_db.inc
+++ b/purchasing/includes/db/supp_trans_db.inc
@@ -258,6 +258,8 @@ function get_sql_for_supplier_inquiry($filter, $after_date, $to_date, $supplier_
 	else {
 		$sql .= " AND trans.tran_date >= '$date_after'
 			AND trans.tran_date <= '$date_to'";
+		$sql2 .= " AND trans.delivery_date >= '$date_after'
+			AND trans.delivery_date <= '$date_to'";
 	}
 
    	if ($supplier_id != ALL_TEXT) {


### PR DESCRIPTION
supplier inquiry displays all GRNs, ignoring the date filter.  This mod adds the date filter to the GRN items.