### PR TITLE
Don't add domain if already exists.

### DIFF
--- a/includes/lang/gettext.inc
+++ b/includes/lang/gettext.inc
@@ -297,7 +297,8 @@ class gettext_php_support extends gettext_native_support
 			$domain .= '-'.$version;
 		}
 
-        if (array_key_exists($domain, $this->_domains)) 
+        $domains = array_map(function($d) {return $d->name;}, $this->_domains);
+        if (in_array($domain, $domains))
         { 
             return; 
         }


### PR DESCRIPTION
The actuall code checking if a domain has already be added using
`add_domain` doesn't work. This can cause memory exhaustion when
sending emails in mass (as each email readd the same domain to the domain list).